### PR TITLE
Create rlang-ffi-lite crate to replace libR-sys

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,8 +70,6 @@ jobs:
           license = "MIT"
           repository = "https://github.com/yutannihilation/savvy/"
           EOF
-          
-          mv Cargo.toml_tmp 
 
           mv savvy/ ./R-package/src/rust/
           mv savvy-macro/ ./R-package/src/rust/

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,10 +47,21 @@ jobs:
 
       - name: Tweak
         run: |
-          # macOS's sed treats -i option differently, so we cannot use it here...
-          sed '/^savvy/s|".*"|"./savvy"|' ./R-package/src/rust/Cargo.toml > Cargo.toml_tmp
-          cat - <<EOF >> Cargo.toml_tmp
-          members = ["savvy", "savvy-macro", "savvy-bindgen"]
+          cat - <<EOF > ./R-package/src/rust/Cargo.toml
+          [package]
+          name = "simple-savvy"
+          version = "0.1.0"
+          edition = "2021"
+
+          [lib]
+          crate-type = ["staticlib"]
+
+          [dependencies]
+          savvy = { path = "./savvy" }
+          rlang-ffi-lite = { path = "./rlang-ffi-lite" }
+
+          [workspace]
+          members = ["savvy", "savvy-macro", "savvy-bindgen", "rlang-ffi-lite"]
 
           [workspace.package]
           version = "0.1.0"
@@ -60,11 +71,12 @@ jobs:
           repository = "https://github.com/yutannihilation/savvy/"
           EOF
           
-          mv Cargo.toml_tmp ./R-package/src/rust/Cargo.toml
+          mv Cargo.toml_tmp 
 
           mv savvy/ ./R-package/src/rust/
           mv savvy-macro/ ./R-package/src/rust/
           mv savvy-bindgen/ ./R-package/src/rust/
+          mv rlang-ffi-lite/ ./R-package/src/rust/
         shell: bash
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
-members = ["savvy", "savvy-macro", "savvy-bindgen", "savvy-cli"]
+members = [
+    "savvy",
+    "savvy-macro",
+    "savvy-bindgen",
+    "savvy-cli",
+    "rlang-ffi-lite",
+    "xtask",
+]
 resolver = "2"
 
 [workspace.package]

--- a/R-package/src/rust/Cargo.lock
+++ b/R-package/src/rust/Cargo.lock
@@ -12,11 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libR-sys"
-version = "0.6.0"
-source = "git+https://github.com/extendr/libR-sys#bcfeb7200416347cf0c400cece7d6561206c46d4"
-
-[[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,18 +42,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlang-ffi-lite"
+version = "0.1.16"
+
+[[package]]
 name = "savvy"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "cc",
- "libR-sys",
  "once_cell",
+ "rlang-ffi-lite",
  "savvy-macro",
 ]
 
 [[package]]
 name = "savvy-bindgen"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -67,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "savvy-macro"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -79,7 +78,7 @@ dependencies = [
 name = "simple-savvy"
 version = "0.1.0"
 dependencies = [
- "libR-sys",
+ "rlang-ffi-lite",
  "savvy",
 ]
 

--- a/R-package/src/rust/Cargo.toml
+++ b/R-package/src/rust/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["staticlib"]
 
 [dependencies]
 savvy = { path = "../../../savvy" }
-libR-sys = { git = "https://github.com/extendr/libR-sys" }
+rlang-ffi-lite = { path = "../../../rlang-ffi-lite" }
 
 [workspace]

--- a/R-package/src/rust/src/error_handling.rs
+++ b/R-package/src/rust/src/error_handling.rs
@@ -15,7 +15,7 @@ fn safe_stop() -> savvy::Result<()> {
 
     savvy::unwind_protect::unwind_protect(|| unsafe {
         let msg = CString::new("Error!").unwrap();
-        libR_sys::Rf_errorcall(libR_sys::R_NilValue, msg.as_ptr());
+        rlang_ffi_lite::Rf_errorcall(rlang_ffi_lite::R_NilValue, msg.as_ptr());
     })?;
 
     Ok(())

--- a/rlang-ffi-lite/Cargo.toml
+++ b/rlang-ffi-lite/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rlang-ffi-lite"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rlang-ffi-lite/src/lib.rs
+++ b/rlang-ffi-lite/src/lib.rs
@@ -1,3 +1,7 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
 // internal types
 
 pub type R_xlen_t = isize;
@@ -38,6 +42,12 @@ pub const WEAKREFSXP: u32 = 23;
 pub const RAWSXP: u32 = 24;
 pub const OBJSXP: u32 = 25;
 
+// pre-defined symbols
+extern "C" {
+    pub static mut R_NamesSymbol: SEXP;
+    pub static mut R_ClassSymbol: SEXP;
+}
+
 // NULL
 extern "C" {
     pub static mut R_NilValue: SEXP;
@@ -66,6 +76,7 @@ extern "C" {
     pub fn INTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
     pub fn SET_INTEGER_ELT(x: SEXP, i: R_xlen_t, v: ::std::os::raw::c_int);
     pub fn Rf_ScalarInteger(arg1: ::std::os::raw::c_int) -> SEXP;
+    pub fn Rf_isInteger(arg1: SEXP) -> Rboolean;
 }
 
 // Real
@@ -74,6 +85,7 @@ extern "C" {
     pub fn REAL_ELT(x: SEXP, i: R_xlen_t) -> f64;
     pub fn SET_REAL_ELT(x: SEXP, i: R_xlen_t, v: f64);
     pub fn Rf_ScalarReal(arg1: f64) -> SEXP;
+    pub fn Rf_isReal(s: SEXP) -> Rboolean;
 }
 
 // Logical
@@ -82,6 +94,7 @@ extern "C" {
     pub fn LOGICAL_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
     pub fn SET_LOGICAL_ELT(x: SEXP, i: R_xlen_t, v: ::std::os::raw::c_int);
     pub fn Rf_ScalarLogical(arg1: ::std::os::raw::c_int) -> SEXP;
+    pub fn Rf_isLogical(s: SEXP) -> Rboolean;
 }
 
 // String and character
@@ -98,12 +111,20 @@ extern "C" {
     pub fn STRING_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
     pub fn SET_STRING_ELT(x: SEXP, i: R_xlen_t, v: SEXP);
     pub fn Rf_ScalarString(arg1: SEXP) -> SEXP;
+    pub fn Rf_isString(s: SEXP) -> Rboolean;
+
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
     pub fn Rf_mkCharLenCE(
         arg1: *const ::std::os::raw::c_char,
         arg2: ::std::os::raw::c_int,
         arg3: cetype_t,
     ) -> SEXP;
+}
+
+// List
+extern "C" {
+    pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
+    pub fn SET_VECTOR_ELT(x: SEXP, i: R_xlen_t, v: SEXP) -> SEXP;
 }
 
 // External pointer
@@ -132,6 +153,12 @@ extern "C" {
     pub fn Rf_protect(arg1: SEXP) -> SEXP;
     pub fn Rf_unprotect(arg1: ::std::os::raw::c_int);
     pub fn R_PreserveObject(arg1: SEXP);
+}
+
+// type
+extern "C" {
+    pub fn TYPEOF(x: SEXP) -> ::std::os::raw::c_int;
+    pub fn Rf_type2char(arg1: SEXPTYPE) -> *const ::std::os::raw::c_char;
 }
 
 // error

--- a/rlang-ffi-lite/src/lib.rs
+++ b/rlang-ffi-lite/src/lib.rs
@@ -1,0 +1,146 @@
+// internal types
+
+pub type R_xlen_t = isize;
+
+pub const Rboolean_FALSE: Rboolean = 0;
+pub const Rboolean_TRUE: Rboolean = 1;
+pub type Rboolean = ::std::os::raw::c_int;
+
+// SEXP
+pub type SEXP = *mut ::std::os::raw::c_void;
+
+// SEXPTYPE
+
+pub type SEXPTYPE = ::std::os::raw::c_uint;
+
+pub const NILSXP: u32 = 0;
+pub const SYMSXP: u32 = 1;
+pub const LISTSXP: u32 = 2;
+pub const CLOSXP: u32 = 3;
+pub const ENVSXP: u32 = 4;
+pub const PROMSXP: u32 = 5;
+pub const LANGSXP: u32 = 6;
+pub const SPECIALSXP: u32 = 7;
+pub const BUILTINSXP: u32 = 8;
+pub const CHARSXP: u32 = 9;
+pub const LGLSXP: u32 = 10;
+pub const INTSXP: u32 = 13;
+pub const REALSXP: u32 = 14;
+pub const CPLXSXP: u32 = 15;
+pub const STRSXP: u32 = 16;
+pub const DOTSXP: u32 = 17;
+pub const ANYSXP: u32 = 18;
+pub const VECSXP: u32 = 19;
+pub const EXPRSXP: u32 = 20;
+pub const BCODESXP: u32 = 21;
+pub const EXTPTRSXP: u32 = 22;
+pub const WEAKREFSXP: u32 = 23;
+pub const RAWSXP: u32 = 24;
+pub const OBJSXP: u32 = 25;
+
+// NULL
+extern "C" {
+    pub static mut R_NilValue: SEXP;
+}
+
+// NA
+extern "C" {
+    pub static mut R_NaInt: ::std::os::raw::c_int;
+    pub static mut R_NaReal: f64;
+    pub static mut R_NaString: SEXP;
+
+    pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
+}
+
+// Allocation and attributes
+extern "C" {
+    pub fn Rf_xlength(arg1: SEXP) -> R_xlen_t;
+    pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
+    pub fn Rf_getAttrib(arg1: SEXP, arg2: SEXP) -> SEXP;
+    pub fn Rf_setAttrib(arg1: SEXP, arg2: SEXP, arg3: SEXP) -> SEXP;
+}
+
+// Integer
+extern "C" {
+    pub fn INTEGER(x: SEXP) -> *mut ::std::os::raw::c_int;
+    pub fn INTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
+    pub fn SET_INTEGER_ELT(x: SEXP, i: R_xlen_t, v: ::std::os::raw::c_int);
+    pub fn Rf_ScalarInteger(arg1: ::std::os::raw::c_int) -> SEXP;
+}
+
+// Real
+extern "C" {
+    pub fn REAL(x: SEXP) -> *mut f64;
+    pub fn REAL_ELT(x: SEXP, i: R_xlen_t) -> f64;
+    pub fn SET_REAL_ELT(x: SEXP, i: R_xlen_t, v: f64);
+    pub fn Rf_ScalarReal(arg1: f64) -> SEXP;
+}
+
+// Logical
+extern "C" {
+    pub fn LOGICAL(x: SEXP) -> *mut ::std::os::raw::c_int;
+    pub fn LOGICAL_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
+    pub fn SET_LOGICAL_ELT(x: SEXP, i: R_xlen_t, v: ::std::os::raw::c_int);
+    pub fn Rf_ScalarLogical(arg1: ::std::os::raw::c_int) -> SEXP;
+}
+
+// String and character
+
+pub const cetype_t_CE_NATIVE: cetype_t = 0;
+pub const cetype_t_CE_UTF8: cetype_t = 1;
+pub const cetype_t_CE_LATIN1: cetype_t = 2;
+pub const cetype_t_CE_BYTES: cetype_t = 3;
+pub const cetype_t_CE_SYMBOL: cetype_t = 5;
+pub const cetype_t_CE_ANY: cetype_t = 99;
+pub type cetype_t = ::std::os::raw::c_int;
+
+extern "C" {
+    pub fn STRING_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
+    pub fn SET_STRING_ELT(x: SEXP, i: R_xlen_t, v: SEXP);
+    pub fn Rf_ScalarString(arg1: SEXP) -> SEXP;
+    pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
+    pub fn Rf_mkCharLenCE(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: cetype_t,
+    ) -> SEXP;
+}
+
+// External pointer
+
+pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
+extern "C" {
+    pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
+    pub fn R_ExternalPtrAddr(s: SEXP) -> *mut ::std::os::raw::c_void;
+    pub fn R_ClearExternalPtr(s: SEXP);
+
+    pub fn R_RegisterCFinalizerEx(s: SEXP, fun: R_CFinalizer_t, onexit: Rboolean);
+}
+
+// Pairlist
+extern "C" {
+    pub fn Rf_cons(arg1: SEXP, arg2: SEXP) -> SEXP;
+    pub fn CAR(e: SEXP) -> SEXP;
+    pub fn CDR(e: SEXP) -> SEXP;
+    pub fn SETCAR(x: SEXP, y: SEXP) -> SEXP;
+    pub fn SETCDR(x: SEXP, y: SEXP) -> SEXP;
+    pub fn SET_TAG(x: SEXP, y: SEXP);
+}
+
+// protection
+extern "C" {
+    pub fn Rf_protect(arg1: SEXP) -> SEXP;
+    pub fn Rf_unprotect(arg1: ::std::os::raw::c_int);
+    pub fn R_PreserveObject(arg1: SEXP);
+}
+
+// error
+extern "C" {
+    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...) -> !;
+}
+
+// I/O
+extern "C" {
+    pub fn Rprintf(arg1: *const ::std::os::raw::c_char, ...);
+    pub fn REprintf(arg1: *const ::std::os::raw::c_char, ...);
+}

--- a/savvy/Cargo.toml
+++ b/savvy/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 readme = "README.md"
 
 [dependencies]
-libR-sys = { version = "0", git = "https://github.com/extendr/libR-sys" }
+rlang-ffi-lite = { verion = "*", path = "../rlang-ffi-lite" }
 once_cell = "1"
 
 savvy-macro = { version = "0", path = "../savvy-macro" }

--- a/savvy/src/error.rs
+++ b/savvy/src/error.rs
@@ -1,4 +1,4 @@
-use libR_sys::SEXP;
+use rlang_ffi_lite::SEXP;
 
 #[derive(Debug)]
 pub enum Error {

--- a/savvy/src/lib.rs
+++ b/savvy/src/lib.rs
@@ -22,10 +22,10 @@ pub use sexp::external_pointer::{get_external_pointer_addr, IntoExtPtrSxp};
 pub use unwind_protect::unwind_protect;
 
 // re-export
-pub use libR_sys::SEXP;
+pub use rlang_ffi_lite::SEXP;
 pub use savvy_macro::savvy;
 
-use libR_sys::{cetype_t_CE_UTF8, REprintf, Rf_allocVector, Rf_mkCharLenCE, Rprintf};
+use rlang_ffi_lite::{cetype_t_CE_UTF8, REprintf, Rf_allocVector, Rf_mkCharLenCE, Rprintf};
 
 use std::ffi::CString;
 

--- a/savvy/src/protect.rs
+++ b/savvy/src/protect.rs
@@ -31,11 +31,11 @@
 // But, my implementation doesn't implement `Clone` trait, so I don't need to
 // worry that there still exists another instance on dropping it.
 
-use libR_sys::{
+use once_cell::sync::Lazy;
+use rlang_ffi_lite::{
     R_NilValue, R_PreserveObject, Rf_cons, Rf_protect, Rf_unprotect, CAR, CDR, SETCAR, SETCDR,
     SET_TAG, SEXP,
 };
-use once_cell::sync::Lazy;
 
 pub(crate) struct PreservedList(SEXP);
 

--- a/savvy/src/sexp/external_pointer.rs
+++ b/savvy/src/sexp/external_pointer.rs
@@ -1,4 +1,4 @@
-use libR_sys::{
+use rlang_ffi_lite::{
     R_ClearExternalPtr, R_ExternalPtrAddr, R_MakeExternalPtr, R_NilValue, R_RegisterCFinalizerEx,
     Rf_protect, Rf_unprotect, SEXP,
 };

--- a/savvy/src/sexp/integer.rs
+++ b/savvy/src/sexp/integer.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use libR_sys::{Rf_xlength, INTEGER, INTSXP, SEXP};
+use rlang_ffi_lite::{Rf_xlength, INTEGER, INTSXP, SEXP};
 
 use super::Sxp;
 use crate::protect;
@@ -158,7 +158,7 @@ impl TryFrom<i32> for OwnedIntegerSxp {
     type Error = crate::error::Error;
 
     fn try_from(value: i32) -> crate::error::Result<Self> {
-        let sexp = unsafe { crate::unwind_protect(|| libR_sys::Rf_ScalarInteger(value))? };
+        let sexp = unsafe { crate::unwind_protect(|| rlang_ffi_lite::Rf_ScalarInteger(value))? };
         Self::new_from_raw_sexp(sexp, 1)
     }
 }

--- a/savvy/src/sexp/list.rs
+++ b/savvy/src/sexp/list.rs
@@ -1,4 +1,4 @@
-use libR_sys::{
+use rlang_ffi_lite::{
     R_NamesSymbol, R_NilValue, Rf_getAttrib, Rf_setAttrib, Rf_xlength, SET_VECTOR_ELT, SEXP,
     TYPEOF, VECSXP, VECTOR_ELT,
 };
@@ -104,12 +104,12 @@ impl ListSxp {
         unsafe {
             let e = VECTOR_ELT(self.0, i as _);
             match TYPEOF(e) as u32 {
-                libR_sys::INTSXP => ListElement::Integer(IntegerSxp(e)),
-                libR_sys::REALSXP => ListElement::Real(RealSxp(e)),
-                libR_sys::STRSXP => ListElement::String(StringSxp(e)),
-                libR_sys::LGLSXP => ListElement::Logical(LogicalSxp(e)),
-                libR_sys::VECSXP => ListElement::List(ListSxp(e)),
-                libR_sys::NILSXP => ListElement::Null(NullSxp),
+                rlang_ffi_lite::INTSXP => ListElement::Integer(IntegerSxp(e)),
+                rlang_ffi_lite::REALSXP => ListElement::Real(RealSxp(e)),
+                rlang_ffi_lite::STRSXP => ListElement::String(StringSxp(e)),
+                rlang_ffi_lite::LGLSXP => ListElement::Logical(LogicalSxp(e)),
+                rlang_ffi_lite::VECSXP => ListElement::List(ListSxp(e)),
+                rlang_ffi_lite::NILSXP => ListElement::Null(NullSxp),
                 _ => ListElement::Unsupported(UnsupportedSxp(e)),
             }
         }

--- a/savvy/src/sexp/logical.rs
+++ b/savvy/src/sexp/logical.rs
@@ -1,4 +1,4 @@
-use libR_sys::{Rf_xlength, LGLSXP, LOGICAL, SET_LOGICAL_ELT, SEXP};
+use rlang_ffi_lite::{Rf_xlength, LGLSXP, LOGICAL, SET_LOGICAL_ELT, SEXP};
 
 use super::Sxp;
 use crate::protect;
@@ -137,7 +137,8 @@ impl TryFrom<bool> for OwnedLogicalSxp {
     type Error = crate::error::Error;
 
     fn try_from(value: bool) -> crate::error::Result<Self> {
-        let sexp = unsafe { crate::unwind_protect(|| libR_sys::Rf_ScalarLogical(value as i32))? };
+        let sexp =
+            unsafe { crate::unwind_protect(|| rlang_ffi_lite::Rf_ScalarLogical(value as i32))? };
         Self::new_from_raw_sexp(sexp, 1)
     }
 }

--- a/savvy/src/sexp/mod.rs
+++ b/savvy/src/sexp/mod.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use libR_sys::{
+use rlang_ffi_lite::{
     Rf_isInteger, Rf_isLogical, Rf_isReal, Rf_isString, Rf_type2char, EXTPTRSXP, SEXP, TYPEOF,
     VECSXP,
 };

--- a/savvy/src/sexp/na.rs
+++ b/savvy/src/sexp/na.rs
@@ -8,28 +8,28 @@ pub trait NotAvailableValue {
 
 impl NotAvailableValue for f64 {
     fn is_na(&self) -> bool {
-        unsafe { libR_sys::R_IsNA(*self) != 0 }
+        unsafe { rlang_ffi_lite::R_IsNA(*self) != 0 }
     }
 
     fn na() -> Self {
-        unsafe { libR_sys::R_NaReal }
+        unsafe { rlang_ffi_lite::R_NaReal }
     }
 }
 
 impl NotAvailableValue for i32 {
     fn is_na(&self) -> bool {
-        unsafe { *self == libR_sys::R_NaInt }
+        unsafe { *self == rlang_ffi_lite::R_NaInt }
     }
 
     fn na() -> Self {
-        unsafe { libR_sys::R_NaInt }
+        unsafe { rlang_ffi_lite::R_NaInt }
     }
 }
 
 use once_cell::sync::Lazy;
 
 pub(crate) static NA_CHAR_PTR: Lazy<&str> = Lazy::new(|| unsafe {
-    let c_ptr = libR_sys::R_CHAR(libR_sys::R_NaString) as _;
+    let c_ptr = rlang_ffi_lite::R_CHAR(rlang_ffi_lite::R_NaString) as _;
     std::str::from_utf8_unchecked(std::slice::from_raw_parts(c_ptr, 2))
 });
 

--- a/savvy/src/sexp/null.rs
+++ b/savvy/src/sexp/null.rs
@@ -1,4 +1,4 @@
-use libR_sys::SEXP;
+use rlang_ffi_lite::SEXP;
 
 /// This is a dummy struct solely for providing `NULL` [Result].
 pub struct NullSxp;
@@ -6,6 +6,6 @@ pub struct NullSxp;
 // Conversion into SEXP is infallible as it's just extract the inner one.
 impl From<NullSxp> for SEXP {
     fn from(_value: NullSxp) -> Self {
-        unsafe { libR_sys::R_NilValue }
+        unsafe { rlang_ffi_lite::R_NilValue }
     }
 }

--- a/savvy/src/sexp/real.rs
+++ b/savvy/src/sexp/real.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use libR_sys::{Rf_xlength, REAL, REALSXP, SEXP};
+use rlang_ffi_lite::{Rf_xlength, REAL, REALSXP, SEXP};
 
 use super::Sxp;
 use crate::protect;
@@ -146,7 +146,7 @@ impl TryFrom<f64> for OwnedRealSxp {
     type Error = crate::error::Error;
 
     fn try_from(value: f64) -> crate::error::Result<Self> {
-        let sexp = unsafe { crate::unwind_protect(|| libR_sys::Rf_ScalarReal(value))? };
+        let sexp = unsafe { crate::unwind_protect(|| rlang_ffi_lite::Rf_ScalarReal(value))? };
         Self::new_from_raw_sexp(sexp, 1)
     }
 }

--- a/savvy/src/sexp/scalar.rs
+++ b/savvy/src/sexp/scalar.rs
@@ -1,4 +1,4 @@
-use libR_sys::LOGICAL_ELT;
+use rlang_ffi_lite::LOGICAL_ELT;
 
 use crate::{IntegerSxp, LogicalSxp, RealSxp, StringSxp, Sxp};
 

--- a/savvy/src/sexp/string.rs
+++ b/savvy/src/sexp/string.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use libR_sys::{
+use rlang_ffi_lite::{
     cetype_t_CE_UTF8, Rf_mkCharLenCE, Rf_xlength, R_CHAR, SET_STRING_ELT, SEXP, STRING_ELT, STRSXP,
 };
 
@@ -100,7 +100,7 @@ unsafe fn str_to_charsxp(v: &str) -> crate::error::Result<SEXP> {
     // <&str>::na(), but probably this is an inevitable cost of
     // providing <&str>::na().
     if v.is_na() {
-        Ok(libR_sys::R_NaString)
+        Ok(rlang_ffi_lite::R_NaString)
     } else {
         crate::unwind_protect(|| {
             Rf_mkCharLenCE(v.as_ptr() as *const i8, v.len() as i32, cetype_t_CE_UTF8)
@@ -150,9 +150,9 @@ impl TryFrom<&str> for OwnedStringSxp {
             // Note: unlike `new()`, this allocates a STRSXP after creating a
             // CHARSXP. So, the `CHARSXP` needs to be protected.
             let charsxp = str_to_charsxp(value)?;
-            libR_sys::Rf_protect(charsxp);
-            let out = crate::unwind_protect(|| libR_sys::Rf_ScalarString(charsxp))?;
-            libR_sys::Rf_unprotect(1);
+            rlang_ffi_lite::Rf_protect(charsxp);
+            let out = crate::unwind_protect(|| rlang_ffi_lite::Rf_ScalarString(charsxp))?;
+            rlang_ffi_lite::Rf_unprotect(1);
             out
         };
         Self::new_from_raw_sexp(sexp, 1)
@@ -216,7 +216,7 @@ impl<'a> Iterator for StringSxpIter<'a> {
 
             // Because `None` means the end of the iterator, we cannot return
             // `None` even for missing values.
-            if e == libR_sys::R_NaString {
+            if e == rlang_ffi_lite::R_NaString {
                 return Some(Self::Item::na());
             }
 

--- a/savvy/src/unwind_protect.rs
+++ b/savvy/src/unwind_protect.rs
@@ -1,4 +1,4 @@
-use libR_sys::SEXP;
+use rlang_ffi_lite::SEXP;
 
 extern "C" {
     fn unwind_protect_impl(

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,0 +1,11 @@
+// From r83513 (R 4.3), R defines the `NORET` macro differently depending on the
+// C/C++ standard the compiler uses. It matters when the header is used in C/C++
+// libraries, but all we want to do here is to make bindgen interpret `NOREP` to
+// `!`. However, for some reason, bindgen doesn't handle other no-return
+// attributes like `_Noreturn` (for C11) and `[[noreturn]]` (for C++ and C23),
+// so we define it here.
+#define NORET __attribute__((__noreturn__))
+
+// Currently, I'm adding these on as-needed basis
+// but we may simply throw the whole lot in in the future.
+#include <Rinternals.h>

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bindgen = "0.69.1"
+
+[package.metadata.dist]
+dist = false

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,5 @@
 type DynError = Box<dyn std::error::Error>;
 use std::env;
-use std::path::PathBuf;
 
 fn main() {
     if let Err(e) = try_main() {
@@ -70,6 +69,9 @@ fn show() -> Result<(), DynError> {
         .allowlist_var("WEAKREFSXP")
         .allowlist_var("RAWSXP")
         .allowlist_var("OBJSXP")
+        // pre-defined symbols
+        .allowlist_var("R_NamesSymbol")
+        .allowlist_var("R_ClassSymbol")
         // NULL-related
         .allowlist_var("R_NilValue")
         // Missing values
@@ -88,22 +90,29 @@ fn show() -> Result<(), DynError> {
         .allowlist_function("INTEGER_ELT")
         .allowlist_function("SET_INTEGER_ELT")
         .allowlist_function("Rf_ScalarInteger")
+        .allowlist_function("Rf_isInteger")
         // Real
         .allowlist_function("REAL")
         .allowlist_function("REAL_ELT")
         .allowlist_function("SET_REAL_ELT")
         .allowlist_function("Rf_ScalarReal")
+        .allowlist_function("Rf_isReal")
         // Logical
         .allowlist_function("LOGICAL")
         .allowlist_function("LOGICAL_ELT")
         .allowlist_function("SET_LOGICAL_ELT")
         .allowlist_function("Rf_ScalarLogical")
+        .allowlist_function("Rf_isLogical")
         // String and character
         .allowlist_function("STRING_ELT")
         .allowlist_function("SET_STRING_ELT")
         .allowlist_function("Rf_ScalarString")
+        .allowlist_function("Rf_isString")
         .allowlist_function("R_CHAR")
         .allowlist_function("Rf_mkCharLenCE")
+        // List
+        .allowlist_function("VECTOR_ELT")
+        .allowlist_function("SET_VECTOR_ELT")
         // External pointer
         .allowlist_function("R_ClearExternalPtr")
         .allowlist_function("R_ExternalPtrAddr")
@@ -120,6 +129,9 @@ fn show() -> Result<(), DynError> {
         .allowlist_function("Rf_protect")
         .allowlist_function("Rf_unprotect")
         .allowlist_function("R_PreserveObject")
+        // type
+        .allowlist_function("Rf_type2char")
+        .allowlist_function("TYPEOF")
         // error
         .allowlist_function("Rf_errorcall")
         // I/O

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,135 @@
+type DynError = Box<dyn std::error::Error>;
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    if let Err(e) = try_main() {
+        eprintln!("{}", e);
+        std::process::exit(-1);
+    }
+}
+
+fn try_main() -> Result<(), DynError> {
+    let task = env::args().nth(1);
+    match task.as_deref() {
+        Some("show") => show()?,
+        _ => print_help(),
+    }
+    Ok(())
+}
+
+fn print_help() {
+    eprintln!(
+        "Tasks:
+
+
+show            show bindgen-generated bindings
+"
+    )
+}
+
+fn show() -> Result<(), DynError> {
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let builder = bindgen::Builder::default().header("wrapper.h").clang_args([
+        format!("-I{}", "C:/Program Files/R/R-devel/include"),
+        // format!("--target={target}"),
+    ]);
+
+    let builder = builder
+        // Basic types and variables
+        .allowlist_type("SEXP")
+        .allowlist_type("cetype_t")
+        .allowlist_type("R_xlen_t")
+        .allowlist_type("Rboolean")
+        //
+        // SEXPTYPEs
+        // cf. https://cran.r-project.org/doc/manuals/r-devel/R-ints.html#SEXPTYPEs
+        .allowlist_type("SEXPTYPE")
+        .allowlist_var("NILSXP")
+        .allowlist_var("SYMSXP")
+        .allowlist_var("LISTSXP")
+        .allowlist_var("CLOSXP")
+        .allowlist_var("ENVSXP")
+        .allowlist_var("PROMSXP")
+        .allowlist_var("LANGSXP")
+        .allowlist_var("SPECIALSXP")
+        .allowlist_var("BUILTINSXP")
+        .allowlist_var("CHARSXP")
+        .allowlist_var("LGLSXP")
+        .allowlist_var("INTSXP")
+        .allowlist_var("REALSXP")
+        .allowlist_var("CPLXSXP")
+        .allowlist_var("STRSXP")
+        .allowlist_var("DOTSXP")
+        .allowlist_var("ANYSXP")
+        .allowlist_var("VECSXP")
+        .allowlist_var("EXPRSXP")
+        .allowlist_var("BCODESXP")
+        .allowlist_var("EXTPTRSXP")
+        .allowlist_var("WEAKREFSXP")
+        .allowlist_var("RAWSXP")
+        .allowlist_var("OBJSXP")
+        // NULL-related
+        .allowlist_var("R_NilValue")
+        // Missing values
+        // - There's no "R_NaLogical" because the internal representation is i32
+        .allowlist_var("R_NaInt")
+        .allowlist_var("R_NaReal")
+        .allowlist_var("R_NaString")
+        .allowlist_function("R_IsNA")
+        // Allocation and attributes
+        .allowlist_function("Rf_xlength")
+        .allowlist_function("Rf_allocVector")
+        .allowlist_function("Rf_getAttrib")
+        .allowlist_function("Rf_setAttrib")
+        // Integer
+        .allowlist_function("INTEGER")
+        .allowlist_function("INTEGER_ELT")
+        .allowlist_function("SET_INTEGER_ELT")
+        .allowlist_function("Rf_ScalarInteger")
+        // Real
+        .allowlist_function("REAL")
+        .allowlist_function("REAL_ELT")
+        .allowlist_function("SET_REAL_ELT")
+        .allowlist_function("Rf_ScalarReal")
+        // Logical
+        .allowlist_function("LOGICAL")
+        .allowlist_function("LOGICAL_ELT")
+        .allowlist_function("SET_LOGICAL_ELT")
+        .allowlist_function("Rf_ScalarLogical")
+        // String and character
+        .allowlist_function("STRING_ELT")
+        .allowlist_function("SET_STRING_ELT")
+        .allowlist_function("Rf_ScalarString")
+        .allowlist_function("R_CHAR")
+        .allowlist_function("Rf_mkCharLenCE")
+        // External pointer
+        .allowlist_function("R_ClearExternalPtr")
+        .allowlist_function("R_ExternalPtrAddr")
+        .allowlist_function("R_MakeExternalPtr")
+        .allowlist_function("R_RegisterCFinalizerEx")
+        // Pairlist
+        .allowlist_function("Rf_cons")
+        .allowlist_function("CAR")
+        .allowlist_function("CDR")
+        .allowlist_function("SETCAR")
+        .allowlist_function("SETCDR")
+        .allowlist_function("SET_TAG")
+        // protection
+        .allowlist_function("Rf_protect")
+        .allowlist_function("Rf_unprotect")
+        .allowlist_function("R_PreserveObject")
+        // error
+        .allowlist_function("Rf_errorcall")
+        // I/O
+        .allowlist_function("Rprintf")
+        .allowlist_function("REprintf");
+
+    let bindings = builder.generate().expect("Unable to generate bindings");
+
+    let stdout = Box::new(std::io::stdout());
+    bindings.write(stdout).expect("Couldn't write bindings!");
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,6 +31,7 @@ fn show() -> Result<(), DynError> {
     println!("cargo:rerun-if-changed=wrapper.h");
 
     let builder = bindgen::Builder::default().header("wrapper.h").clang_args([
+        // TODO: this works only on my Windows laptop...
         format!("-I{}", "C:/Program Files/R/R-devel/include"),
         // format!("--target={target}"),
     ]);


### PR DESCRIPTION
Since the savvy framework uses only a subset of APIs, a simpler one is a better fit. Let's handcraft the minimal definitions.

`xtask` is added for verifying and updating the definitions. This design is inspired by pyo3's structure.