### PR TITLE
Allow arbitrary type of input

### DIFF
--- a/R-package/R/wrappers.R
+++ b/R-package/R/wrappers.R
@@ -147,6 +147,11 @@ sum_real <- function(x) {
   .Call(sum_real__impl, x)
 }
 
+
+my_integer <- function(x) {
+  invisible(.Call(my_integer__impl, x))
+}
+
 #' A person with a name
 #'
 #' @export

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -157,6 +157,11 @@ SEXP sum_real__impl(SEXP x) {
     return handle_result(res);
 }
 
+SEXP my_integer__impl(SEXP x) {
+    SEXP res = my_integer(x);
+    return handle_result(res);
+}
+
 
 static const R_CallMethodDef CallEntries[] = {
     {"safe_stop__impl", (DL_FUNC) &safe_stop__impl, 0},
@@ -184,6 +189,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"scalar_output_string__impl", (DL_FUNC) &scalar_output_string__impl, 0},
     {"sum_int__impl", (DL_FUNC) &sum_int__impl, 1},
     {"sum_real__impl", (DL_FUNC) &sum_real__impl, 1},
+    {"my_integer__impl", (DL_FUNC) &my_integer__impl, 1},
     {NULL, NULL, 0}
 };
 

--- a/R-package/src/rust/api.h
+++ b/R-package/src/rust/api.h
@@ -19,6 +19,7 @@ SEXP scalar_output_logical(void);
 SEXP scalar_output_string(void);
 SEXP sum_int(SEXP x);
 SEXP sum_real(SEXP x);
+SEXP my_integer(SEXP x);
 
 // methods and associated functions for Person
 SEXP Person_new(void);

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -6,6 +6,9 @@ pub use scalar::*;
 mod error_handling;
 pub use error_handling::*;
 
+mod try_from;
+pub use try_from::*;
+
 use savvy::{r_print, savvy};
 
 use savvy::{

--- a/R-package/src/rust/src/try_from.rs
+++ b/R-package/src/rust/src/try_from.rs
@@ -1,0 +1,19 @@
+use savvy::savvy;
+
+#[derive(Debug)]
+struct MyInteger(i32);
+
+impl TryFrom<savvy::Sxp> for MyInteger {
+    type Error = savvy::Error;
+
+    fn try_from(value: savvy::Sxp) -> savvy::Result<Self> {
+        let i: i32 = value.try_into()?;
+        Ok(Self(i))
+    }
+}
+
+#[savvy]
+fn my_integer(x: MyInteger) -> savvy::Result<()> {
+    savvy::r_print(&format!("{:?}\n", x))?;
+    Ok(())
+}

--- a/R-package/tests/testthat/_snaps/custom-type.md
+++ b/R-package/tests/testthat/_snaps/custom-type.md
@@ -1,0 +1,7 @@
+# Functions with custom types work
+
+    Code
+      my_integer(1L)
+    Output
+      MyInteger(1)
+

--- a/R-package/tests/testthat/test-custom-type.R
+++ b/R-package/tests/testthat/test-custom-type.R
@@ -1,0 +1,3 @@
+test_that("Functions with custom types work", {
+  expect_snapshot(my_integer(1L))
+})

--- a/savvy-macro/tests/cases/simple_cases.rs
+++ b/savvy-macro/tests/cases/simple_cases.rs
@@ -1,15 +1,6 @@
 use savvy_macro::savvy;
 
 #[savvy]
-fn foo_ref(&x: i32) -> savvy::Result<()> {}
-
-#[savvy]
-fn foo_mut_ref(&mut x: i32) -> savvy::Result<()> {}
-
-#[savvy]
-fn foo_unsupported1(x: usize) -> savvy::Result<()> {}
-
-#[savvy]
 fn foo_no_return_type(x: i32) {}
 
 #[savvy]

--- a/savvy-macro/tests/cases/simple_cases.stderr
+++ b/savvy-macro/tests/cases/simple_cases.stderr
@@ -1,37 +1,19 @@
-error: non-ident is not supported
- --> tests/cases/simple_cases.rs:4:12
-  |
-4 | fn foo_ref(&x: i32) -> savvy::Result<()> {}
-  |            ^^
-
-error: non-ident is not supported
- --> tests/cases/simple_cases.rs:7:16
-  |
-7 | fn foo_mut_ref(&mut x: i32) -> savvy::Result<()> {}
-  |                ^^^^^^
-
-error: Unsupported type
-  --> tests/cases/simple_cases.rs:10:24
-   |
-10 | fn foo_unsupported1(x: usize) -> savvy::Result<()> {}
-   |                        ^^^^^
-
 error: function must have return type
-  --> tests/cases/simple_cases.rs:12:1
-   |
-12 | #[savvy]
-   | ^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `savvy` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> tests/cases/simple_cases.rs:3:1
+  |
+3 | #[savvy]
+  | ^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `savvy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the return type must be either syn::Result<SEXP> or syn::Result<()>
-  --> tests/cases/simple_cases.rs:16:34
-   |
-16 | fn foo_wrong_return_type(x: i32) -> i32 {}
-   |                                  ^^^^^^
+ --> tests/cases/simple_cases.rs:7:34
+  |
+7 | fn foo_wrong_return_type(x: i32) -> i32 {}
+  |                                  ^^^^^^
 
 error: For safety, a function that takes `self` and returns `Self` is not allowed
-  --> tests/cases/simple_cases.rs:22:5
+  --> tests/cases/simple_cases.rs:13:5
    |
-22 |     fn foo_self(&self) -> Self {}
+13 |     fn foo_self(&self) -> Self {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Do not check input and allow arbitrary types as long as it implements `TryFrom<Sxp>`