### PR TITLE
Initialize SEXP allocated by Rf_allocVector

### DIFF
--- a/savvy/src/sexp/list.rs
+++ b/savvy/src/sexp/list.rs
@@ -135,6 +135,14 @@ impl OwnedListSexp {
         let out = crate::alloc_vector(VECSXP, len as _)?;
         let token = protect::insert_to_preserved_list(out);
 
+        // Note: `R_allocVector()` initializes lists, so we don't need to do it
+        // by ourselves. R-exts (5.9.2 Allocating storage) says:
+        //
+        // >  One distinction is that whereas the R functions always initialize
+        // >  the elements of the vector, allocVector only does so for lists,
+        // >  expressions and character vectors (the cases where the elements
+        // >  are themselves R objects).
+
         let names = if named {
             let names = OwnedStringSexp::new(len)?;
             unsafe { Rf_setAttrib(out, R_NamesSymbol, names.inner()) };

--- a/savvy/src/sexp/string.rs
+++ b/savvy/src/sexp/string.rs
@@ -71,6 +71,15 @@ impl OwnedStringSexp {
 
     fn new_from_raw_sexp(inner: SEXP, len: usize) -> crate::error::Result<Self> {
         let token = protect::insert_to_preserved_list(inner);
+
+        // Note: `R_allocVector()` initializes character vectors, so we don't
+        // need to do it by ourselves. R-exts (5.9.2 Allocating storage) says:
+        //
+        // >  One distinction is that whereas the R functions always initialize
+        // >  the elements of the vector, allocVector only does so for lists,
+        // >  expressions and character vectors (the cases where the elements
+        // >  are themselves R objects).
+
         Ok(Self { inner, token, len })
     }
 }


### PR DESCRIPTION
[R-exts](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Allocating-storage) says:

>  One distinction is that whereas the R functions always initialize the elements of the vector, `allocVector` only does so for lists, expressions and character vectors (the cases where the elements are themselves R objects). 

But I forgot to implement it. cpp11 initializes by using `SET_ELT_*()`. But, as the SEXP allocated by `Rf_allocVector()` should be supposed to be non-ALTREP, we should be able to manipulate the underlying memory directly.