### PR TITLE
Use std::ptr::write_bytes() for initialization

### DIFF
--- a/savvy/src/sexp/integer.rs
+++ b/savvy/src/sexp/integer.rs
@@ -107,10 +107,8 @@ impl OwnedIntegerSexp {
 
         // Fill the vector with default values
         if init {
-            for i in 0..len {
-                unsafe {
-                    *(raw.add(i)) = i32::default();
-                }
+            unsafe {
+                std::ptr::write_bytes(raw, 0, len);
             }
         }
 

--- a/savvy/src/sexp/logical.rs
+++ b/savvy/src/sexp/logical.rs
@@ -85,10 +85,8 @@ impl OwnedLogicalSexp {
 
         // Fill the vector with default values
         if init {
-            for i in 0..len {
-                unsafe {
-                    *(raw.add(i)) = i32::default();
-                }
+            unsafe {
+                std::ptr::write_bytes(raw, 0, len);
             }
         }
 

--- a/savvy/src/sexp/real.rs
+++ b/savvy/src/sexp/real.rs
@@ -95,10 +95,8 @@ impl OwnedRealSexp {
 
         // Fill the vector with default values
         if init {
-            for i in 0..len {
-                unsafe {
-                    *(raw.add(i)) = f64::default();
-                }
+            unsafe {
+                std::ptr::write_bytes(raw, 0, len);
             }
         }
 


### PR DESCRIPTION
I'm not really sure if pursuing speed is worth here. But, probably this is not very dangerous to use.

https://doc.rust-lang.org/std/ptr/fn.write_bytes.html