### PR TITLE
Make r_print() and r_eprint() to macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## savvy 0.2.x (Unreleased)
+
+* `r_print!` and `r_eprint!` are now macro that wraps `format!`, so you can use
+  them just like Rust's `print!` macro. There are also `r_println!` and
+  `r_eprintln!` available.

--- a/R-package/src/rust/src/convert_from_rust_types.rs
+++ b/R-package/src/rust/src/convert_from_rust_types.rs
@@ -4,31 +4,31 @@ use savvy::{savvy, IntegerSexp, RealSexp};
 
 #[savvy]
 fn scalar_input_int(x: i32) -> savvy::Result<()> {
-    savvy::r_print(&format!("{}\n", x))?;
+    savvy::r_println!("{}", x);
     Ok(())
 }
 
 #[savvy]
 fn scalar_input_usize(x: usize) -> savvy::Result<()> {
-    savvy::r_print(&format!("{}\n", x))?;
+    savvy::r_println!("{}", x);
     Ok(())
 }
 
 #[savvy]
 fn scalar_input_real(x: f64) -> savvy::Result<()> {
-    savvy::r_print(&format!("{}\n", x))?;
+    savvy::r_println!("{}", x);
     Ok(())
 }
 
 #[savvy]
 fn scalar_input_logical(x: bool) -> savvy::Result<()> {
-    savvy::r_print(&format!("{}\n", x))?;
+    savvy::r_println!("{}", x);
     Ok(())
 }
 
 #[savvy]
 fn scalar_input_string(x: &str) -> savvy::Result<()> {
-    savvy::r_print(&format!("{}\n", x))?;
+    savvy::r_println!("{}", x);
     Ok(())
 }
 

--- a/R-package/src/rust/src/convert_from_rust_types.rs
+++ b/R-package/src/rust/src/convert_from_rust_types.rs
@@ -4,31 +4,31 @@ use savvy::{savvy, IntegerSexp, RealSexp};
 
 #[savvy]
 fn scalar_input_int(x: i32) -> savvy::Result<()> {
-    savvy::r_println!("{}", x);
+    savvy::r_println!("{x}");
     Ok(())
 }
 
 #[savvy]
 fn scalar_input_usize(x: usize) -> savvy::Result<()> {
-    savvy::r_println!("{}", x);
+    savvy::r_println!("{x}");
     Ok(())
 }
 
 #[savvy]
 fn scalar_input_real(x: f64) -> savvy::Result<()> {
-    savvy::r_println!("{}", x);
+    savvy::r_println!("{x}");
     Ok(())
 }
 
 #[savvy]
 fn scalar_input_logical(x: bool) -> savvy::Result<()> {
-    savvy::r_println!("{}", x);
+    savvy::r_println!("{x}");
     Ok(())
 }
 
 #[savvy]
 fn scalar_input_string(x: &str) -> savvy::Result<()> {
-    savvy::r_println!("{}", x);
+    savvy::r_println!("{x}");
     Ok(())
 }
 

--- a/R-package/src/rust/src/error_handling.rs
+++ b/R-package/src/rust/src/error_handling.rs
@@ -5,7 +5,7 @@ struct Foo {}
 impl Drop for Foo {
     fn drop(&mut self) {
         // If Foo is dropped, this message should be emmited.
-        let _ = savvy::r_print("Foo is Dropped!\n");
+        savvy::r_println!("Foo is Dropped!");
     }
 }
 

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -229,7 +229,7 @@ fn print_list(x: ListSexp) -> savvy::Result<()> {
 
         let name = if k.is_empty() { "(no name)" } else { k };
 
-        r_print(format!("{name}: {content}\n").as_str())?;
+        r_print!("{name}: {content}\n");
     }
 
     Ok(())

--- a/R-package/src/rust/src/try_from.rs
+++ b/R-package/src/rust/src/try_from.rs
@@ -1,4 +1,4 @@
-use savvy::savvy;
+use savvy::{savvy, IntegerSexp};
 
 #[derive(Debug)]
 struct MyInteger(i32);
@@ -14,6 +14,6 @@ impl TryFrom<savvy::Sexp> for MyInteger {
 
 #[savvy]
 fn my_integer(x: MyInteger) -> savvy::Result<()> {
-    savvy::r_print!("{:?}\n", x);
+    savvy::r_println!("{x:?}");
     Ok(())
 }

--- a/R-package/src/rust/src/try_from.rs
+++ b/R-package/src/rust/src/try_from.rs
@@ -14,6 +14,6 @@ impl TryFrom<savvy::Sexp> for MyInteger {
 
 #[savvy]
 fn my_integer(x: MyInteger) -> savvy::Result<()> {
-    savvy::r_print(&format!("{:?}\n", x))?;
+    savvy::r_print!("{:?}\n", x);
     Ok(())
 }

--- a/R-package/src/rust/src/try_from.rs
+++ b/R-package/src/rust/src/try_from.rs
@@ -1,4 +1,4 @@
-use savvy::{savvy, IntegerSexp};
+use savvy::savvy;
 
 #[derive(Debug)]
 struct MyInteger(i32);

--- a/savvy/docs/design.md
+++ b/savvy/docs/design.md
@@ -447,11 +447,11 @@ same as `INTSXP`. So, the conversion should be cheap.
 fn some_savvy_fun(logical: IntegerSexp) -> savvy::Result<()> {
     for l in logical.iter() {
         if l.is_na() {
-            r_print("NA\n");
+            r_print!("NA\n");
         } else if *l == 1 {
-            r_print("TRUE\n");
+            r_print!("TRUE\n");
         } else {
-            r_print("FALSE\n");
+            r_print!("FALSE\n");
         }
     }
 
@@ -539,11 +539,11 @@ possible because it's too complex.
 fn print_list_names(x: ListSexp) -> savvy::Result<()> {
     for k in x.names_iter() {
         if k.is_empty() {
-            r_print("(no name)")?;
+            r_println!("(no name)");
         } else {
-            r_print(k)?;
+            r_println!(k);
         }
-        r_print("\n")?;
+        r_println!("");
     }
 
     Ok(())
@@ -567,8 +567,8 @@ to extract the inner data.
 fn print_list_values_if_int(x: ListSexp) -> savvy::Result<()>  {
     for v in x.values_iter() {
         match v {
-            TypedSexp::Integer(i) => r_print(&format!("int {}\n", i.as_slice()[0]))?,
-            _ => r_print("not int\n")?
+            TypedSexp::Integer(i) => r_println!("int {}\n", i.as_slice()[0]),
+            _ => r_println("not int")
         }
     }
 

--- a/savvy/src/io.rs
+++ b/savvy/src/io.rs
@@ -1,0 +1,29 @@
+use savvy_ffi::{REprintf, Rprintf};
+
+use std::ffi::CString;
+
+use crate::unwind_protect;
+
+pub fn r_print(msg: &str) -> crate::error::Result<()> {
+    unsafe {
+        let msg_c_string = CString::new(msg).unwrap();
+        unwind_protect(|| {
+            Rprintf(msg_c_string.as_ptr());
+            savvy_ffi::R_NilValue
+        })?;
+
+        Ok(())
+    }
+}
+
+pub fn r_eprint(msg: &str) -> crate::error::Result<()> {
+    unsafe {
+        let msg_c_string = CString::new(msg).unwrap();
+        unwind_protect(|| {
+            REprintf(msg_c_string.as_ptr());
+            savvy_ffi::R_NilValue
+        })?;
+
+        Ok(())
+    }
+}

--- a/savvy/src/io.rs
+++ b/savvy/src/io.rs
@@ -1,29 +1,32 @@
 use savvy_ffi::{REprintf, Rprintf};
 
+use once_cell::sync::Lazy;
 use std::ffi::CString;
 
-use crate::unwind_protect;
+pub(crate) static LINEBREAK: Lazy<CString> = Lazy::new(|| CString::new("\n").unwrap());
 
-pub fn r_print(msg: &str) -> crate::error::Result<()> {
+pub fn r_print(msg: &str, linebreak: bool) {
     unsafe {
-        let msg_c_string = CString::new(msg).unwrap();
-        unwind_protect(|| {
+        if !msg.is_empty() {
+            let msg_c_string = CString::new(msg).unwrap();
             Rprintf(msg_c_string.as_ptr());
-            savvy_ffi::R_NilValue
-        })?;
+        }
 
-        Ok(())
+        if linebreak {
+            Rprintf(LINEBREAK.as_ptr());
+        }
     }
 }
 
-pub fn r_eprint(msg: &str) -> crate::error::Result<()> {
+pub fn r_eprint(msg: &str, linebreak: bool) {
     unsafe {
-        let msg_c_string = CString::new(msg).unwrap();
-        unwind_protect(|| {
+        if !msg.is_empty() {
+            let msg_c_string = CString::new(msg).unwrap();
             REprintf(msg_c_string.as_ptr());
-            savvy_ffi::R_NilValue
-        })?;
+        }
 
-        Ok(())
+        if linebreak {
+            REprintf(LINEBREAK.as_ptr());
+        }
     }
 }

--- a/savvy/src/lib.rs
+++ b/savvy/src/lib.rs
@@ -61,23 +61,23 @@ pub fn handle_error(e: crate::error::Error) -> SEXP {
 #[macro_export]
 macro_rules! r_print {
     () => {};
-    ($($rest: tt)*) => { savvy::io::r_print(&format!($($rest)*), false); };
+    ($($arg:tt)*) => { savvy::io::r_print(&format!($($arg)*), false); };
 }
 
 #[macro_export]
 macro_rules! r_eprint {
     () => {};
-    ($($rest: tt)*) => { savvy::io::r_eprint(&format!($($rest)*), false); };
+    ($($arg:tt)*) => { savvy::io::r_eprint(&format!($($arg)*), false); };
 }
 
 #[macro_export]
 macro_rules! r_println {
     () => {};
-    ($($rest: tt)*) => { savvy::io::r_print(&format!($($rest)*), true); };
+    ($($arg:tt)*) => { savvy::io::r_print(&format!($($arg)*), true); };
 }
 
 #[macro_export]
 macro_rules! r_eprintln {
     () => {};
-    ($($rest: tt)*) => { savvy::io::r_eprint(&format!($($rest)*), true); };
+    ($($arg:tt)*) => { savvy::io::r_eprint(&format!($($arg)*), true); };
 }

--- a/savvy/src/lib.rs
+++ b/savvy/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod error;
 pub mod ffi;
+pub mod io;
 pub mod protect;
 pub mod sexp;
 pub mod unwind_protect;
@@ -26,32 +27,7 @@ pub use unwind_protect::unwind_protect;
 pub use savvy_macro::savvy;
 
 use ffi::SEXP;
-use savvy_ffi::{cetype_t_CE_UTF8, REprintf, Rf_allocVector, Rf_mkCharLenCE, Rprintf};
-
-use std::ffi::CString;
-
-// TODO: make this r_println! macro
-pub fn r_print(msg: &str) -> crate::error::Result<Sexp> {
-    unsafe {
-        let msg_c_string = CString::new(msg).unwrap();
-        unwind_protect(|| {
-            Rprintf(msg_c_string.as_ptr());
-            savvy_ffi::R_NilValue
-        })
-        .map(Sexp)
-    }
-}
-
-pub fn r_eprint(msg: &str) -> crate::error::Result<Sexp> {
-    unsafe {
-        let msg_c_string = CString::new(msg).unwrap();
-        unwind_protect(|| {
-            REprintf(msg_c_string.as_ptr());
-            savvy_ffi::R_NilValue
-        })
-        .map(Sexp)
-    }
-}
+use savvy_ffi::{cetype_t_CE_UTF8, Rf_allocVector, Rf_mkCharLenCE};
 
 fn alloc_vector(arg1: u32, arg2: isize) -> crate::error::Result<SEXP> {
     unsafe { unwind_protect(|| Rf_allocVector(arg1, arg2)) }

--- a/savvy/src/lib.rs
+++ b/savvy/src/lib.rs
@@ -57,3 +57,27 @@ pub fn handle_error(e: crate::error::Error) -> SEXP {
         },
     }
 }
+
+#[macro_export]
+macro_rules! r_print {
+    () => {};
+    ($($rest: tt)*) => { savvy::io::r_print(&format!($($rest)*), false); };
+}
+
+#[macro_export]
+macro_rules! r_eprint {
+    () => {};
+    ($($rest: tt)*) => { savvy::io::r_eprint(&format!($($rest)*), false); };
+}
+
+#[macro_export]
+macro_rules! r_println {
+    () => {};
+    ($($rest: tt)*) => { savvy::io::r_print(&format!($($rest)*), true); };
+}
+
+#[macro_export]
+macro_rules! r_eprintln {
+    () => {};
+    ($($rest: tt)*) => { savvy::io::r_eprint(&format!($($rest)*), true); };
+}


### PR DESCRIPTION
Note: I'm not really sure if `Rprintf()` and `REprintf()` is infallible, but, for ergonomics, it's a bit frustrating to always add `?` or `unwrap()` to the macro. So, let's assume they are infallible.