### PR TITLE
Implement ExternalPointerSexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Add `is_null()`.
 * Add `as_read_only()` to `OwnedListSexp` as well.
+* Add `downcast()` for casting an external pointer to a concrete type. Note that
+  this is only needed for "external" external pointers.
 
 ## [v0.2.4] (2024-01-15)
 

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -224,6 +224,7 @@ fn print_list(x: ListSexp) -> savvy::Result<()> {
             }
             TypedSexp::List(_) => "list".to_string(),
             TypedSexp::Null(_) => "NULL".to_string(),
+            TypedSexp::ExternalPointer(_) => "external pointer".to_string(),
             TypedSexp::Other(_) => "Unsupported".to_string(),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use sexp::real::{OwnedRealSexp, RealSexp};
 pub use sexp::string::{OwnedStringSexp, StringSexp};
 pub use sexp::{Sexp, TypedSexp};
 
-pub use sexp::external_pointer::{get_external_pointer_addr, IntoExtPtrSexp};
+pub use sexp::external_pointer::{get_external_pointer_addr, ExternalPointerSexp, IntoExtPtrSexp};
 
 pub use unwind_protect::unwind_protect;
 

--- a/src/sexp/mod.rs
+++ b/src/sexp/mod.rs
@@ -6,8 +6,8 @@ use savvy_ffi::{
 };
 
 use crate::{
-    IntegerSexp, ListSexp, LogicalSexp, NullSexp, OwnedIntegerSexp, OwnedLogicalSexp,
-    OwnedRealSexp, OwnedStringSexp, RealSexp, StringSexp,
+    ExternalPointerSexp, IntegerSexp, ListSexp, LogicalSexp, NullSexp, OwnedIntegerSexp,
+    OwnedLogicalSexp, OwnedRealSexp, OwnedStringSexp, RealSexp, StringSexp,
 };
 
 pub mod external_pointer;
@@ -83,6 +83,7 @@ pub enum TypedSexp {
     Logical(LogicalSexp),
     List(ListSexp),
     Null(NullSexp),
+    ExternalPointer(ExternalPointerSexp),
     Other(SEXP),
 }
 
@@ -101,6 +102,7 @@ into_typed_sxp!(RealSexp, Real);
 into_typed_sxp!(StringSexp, String);
 into_typed_sxp!(LogicalSexp, Logical);
 into_typed_sxp!(ListSexp, List);
+into_typed_sxp!(ExternalPointerSexp, ExternalPointer);
 into_typed_sxp!(NullSexp, Null);
 
 macro_rules! into_typed_sxp_owned {
@@ -127,6 +129,7 @@ impl From<TypedSexp> for SEXP {
             TypedSexp::String(sxp) => sxp.inner(),
             TypedSexp::Logical(sxp) => sxp.inner(),
             TypedSexp::List(sxp) => sxp.inner(),
+            TypedSexp::ExternalPointer(sxp) => sxp.inner(),
             TypedSexp::Other(sxp) => sxp,
         }
     }
@@ -142,6 +145,7 @@ impl Sexp {
             savvy_ffi::STRSXP => TypedSexp::String(StringSexp(self.0)),
             savvy_ffi::LGLSXP => TypedSexp::Logical(LogicalSexp(self.0)),
             savvy_ffi::VECSXP => TypedSexp::List(ListSexp(self.0)),
+            savvy_ffi::EXTPTRSXP => TypedSexp::ExternalPointer(ExternalPointerSexp(self.0)),
             savvy_ffi::NILSXP => TypedSexp::Null(NullSexp),
             _ => TypedSexp::Other(self.0),
         }


### PR DESCRIPTION
While this is not recommended, I found there's no option other than this when we deal with external pointers created outside.