### PR TITLE
Do not use copy_from_slice() for to_vec()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### Fixed bugs
+
+* Fix the wrong implementation of `to_vec()`.
+
 ## [v0.2.9] (2024-01-27)
 
 ### Breaking changes

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -34,9 +34,7 @@ impl IntegerSexp {
     }
 
     pub fn to_vec(&self) -> Vec<i32> {
-        let mut out = Vec::with_capacity(self.len());
-        out.copy_from_slice(self.as_slice());
-        out
+        self.as_slice().to_vec()
     }
 }
 
@@ -62,9 +60,7 @@ impl OwnedIntegerSexp {
     }
 
     pub fn to_vec(&self) -> Vec<i32> {
-        let mut out = Vec::with_capacity(self.len());
-        out.copy_from_slice(self.as_slice());
-        out
+        self.as_slice().to_vec()
     }
 
     pub fn set_elt(&mut self, i: usize, v: i32) -> crate::error::Result<()> {

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -30,9 +30,7 @@ impl RealSexp {
     }
 
     pub fn to_vec(&self) -> Vec<f64> {
-        let mut out = Vec::with_capacity(self.len());
-        out.copy_from_slice(self.as_slice());
-        out
+        self.as_slice().to_vec()
     }
 }
 
@@ -58,9 +56,7 @@ impl OwnedRealSexp {
     }
 
     pub fn to_vec(&self) -> Vec<f64> {
-        let mut out = Vec::with_capacity(self.len);
-        out.copy_from_slice(self.as_slice());
-        out
+        self.as_slice().to_vec()
     }
 
     pub fn set_elt(&mut self, i: usize, v: f64) -> crate::error::Result<()> {


### PR DESCRIPTION
This code always panics because the length of `out` is 0. I could set it by `set_len()`, but probably it's not worth having my own implementation here. Let's rely on the standard `to_vec()`.

```rust
        let mut out = Vec::with_capacity(self.len());
        out.copy_from_slice(self.as_slice());
        out
```