### PR TITLE
Make `get_dim()` return an `IntegerSexp`

### DIFF
--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -1,7 +1,7 @@
 use savvy_ffi::{LGLSXP, LOGICAL, SET_LOGICAL_ELT, SEXP};
 
 use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
-use crate::protect;
+use crate::{protect, IntegerSexp};
 
 /// An external SEXP of a logical vector.
 pub struct LogicalSexp(pub SEXP);

--- a/src/sexp/mod.rs
+++ b/src/sexp/mod.rs
@@ -249,20 +249,14 @@ impl Sexp {
     }
 }
 
-pub(crate) fn get_dim_from_sexp(value: SEXP) -> Option<Vec<usize>> {
+pub(crate) fn get_dim_from_sexp(value: SEXP) -> Option<IntegerSexp> {
     let dim_sexp = unsafe { savvy_ffi::Rf_getAttrib(value, savvy_ffi::R_DimSymbol) };
 
     if dim_sexp == unsafe { savvy_ffi::R_NilValue } {
         None
     // Bravely assume the "dim" attribute is always a valid INTSXP.
     } else {
-        Some(
-            crate::IntegerSexp(dim_sexp)
-                .as_slice()
-                .iter()
-                .map(|i| *i as _)
-                .collect(),
-        )
+        Some(crate::IntegerSexp(dim_sexp))
     }
 }
 
@@ -312,7 +306,7 @@ macro_rules! impl_common_sexp_ops {
             }
 
             /// Returns the dimension.
-            pub fn get_dim(&self) -> Option<Vec<usize>> {
+            pub fn get_dim(&self) -> Option<IntegerSexp> {
                 crate::sexp::get_dim_from_sexp(self.inner())
             }
         }
@@ -356,7 +350,7 @@ macro_rules! impl_common_sexp_ops_owned {
             }
 
             /// Returns the dimension.
-            pub fn get_dim(&self) -> Option<Vec<usize>> {
+            pub fn get_dim(&self) -> Option<IntegerSexp> {
                 crate::sexp::get_dim_from_sexp(self.inner())
             }
 

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -3,7 +3,7 @@ use std::ops::{Index, IndexMut};
 use savvy_ffi::{REAL, REALSXP, SEXP};
 
 use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
-use crate::protect;
+use crate::{protect, IntegerSexp};
 
 /// An external SEXP of a real vector.
 pub struct RealSexp(pub SEXP);

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -7,7 +7,7 @@ use savvy_ffi::{
 
 use super::na::NotAvailableValue;
 use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
-use crate::protect;
+use crate::{protect, IntegerSexp};
 
 /// An external SEXP of a character vector.
 pub struct StringSexp(pub SEXP);


### PR DESCRIPTION
Make `get_dim()` return an `IntegerSexp`, avoiding another vec allocation when sometimes not needed.

I think maybe the same can be done to `get_class` and `get_names`, to return StringSexp instead. Let me know what you think and I can make that change as well.

I am not able to run cargo test, so please let me know of any errors. I think your CI will probably catch any mistake, specially with tests.