### PR TITLE
Change the return type of get_dim() to Option<&[i32]>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### Breaking changes
+
+* `get_dim()` now returns `&[i32]` instead of `Vec<usize>` to avoid allocation.
+  If the matrix library requires `usize`, you need to convert the `i32` to
+  `usize` by yourself now.
+  Accordingly, `set_dim()` now accepts both `&[i32]` and `&[usize]`.
+
 ## [v0.2.16] (2024-03-03)
 
 ### Breaking changes

--- a/R-package/src/rust/src/attributes.rs
+++ b/R-package/src/rust/src/attributes.rs
@@ -19,7 +19,10 @@ fn get_names_int(x: savvy::IntegerSexp) -> savvy::Result<savvy::Sexp> {
 #[savvy]
 fn get_dim_int(x: savvy::IntegerSexp) -> savvy::Result<savvy::Sexp> {
     match x.get_dim() {
-        Some(dim) => dim.iter().map(|i| *i as _).collect::<Vec<i32>>().try_into(),
+        Some(dim) => {
+            let x: OwnedIntegerSexp = dim.to_vec().try_into()?;
+            x.into()
+        }
         None => ().try_into(),
     }
 }

--- a/book/src/12_attributes.md
+++ b/book/src/12_attributes.md
@@ -9,7 +9,7 @@ attribute.
 |:----------|:--------------|:--------------|:-------------|
 | `names`   | `get_names()` |`set_names()`  | `Vec<&str>`  |
 | `class`   | `get_class()` |`set_class()`  | `Vec<&str>`  |
-| `dim`     | `get_dim()`   |`set_dim()`    | `Vec<usize>` |
+| `dim`     | `get_dim()`   |`set_dim()`    | `&[i32]`     |
 | arbitrary | `get_attrib()`|`set_attrib()` | `Sexp`       |
 
 The getter methods return `Option<T>` because the object doesn't always have the

--- a/book/src/15_matrix.md
+++ b/book/src/15_matrix.md
@@ -26,7 +26,9 @@ use savvy::{r_println, savvy, RealSexp};
 
 #[savvy]
 fn ndarray_input(x: RealSexp) -> savvy::Result<()> {
-    let dim = x.get_dim().ok_or("no dimension found")?;
+    // In R, dim is i32, so you need to convert it to usize first.
+    let dim_i32 = x.get_dim().ok_or("no dimension found")?;
+    let dim: Vec<usize> = dim_i32.iter().map(|i| *i as usize).collect();
 
     // f() changes the order from row-major (C-style convention) to column-major (Fortran-style convention).
     let a = Array::from_shape_vec(dim.f(), x.to_vec());
@@ -53,7 +55,7 @@ fn nalgebra_input(x: RealSexp) -> savvy::Result<()> {
         return Err("Input must be matrix!".into());
     }
 
-    let m = DMatrix::from_vec(dim[0], dim[1], x.to_vec());
+    let m = DMatrix::from_vec(dim[0] as _, dim[1] as _, x.to_vec());
 
     r_println!("{m:?}");
 
@@ -75,7 +77,7 @@ use savvy::{r_println, savvy, OwnedRealSexp, RealSexp};
 fn glam_input(x: RealSexp) -> savvy::Result<()> {
     let dim = x.get_dim().ok_or("no dimension found")?;
 
-    if dim.as_slice() != [3, 3] {
+    if dim != [3, 3] {
         return Err("Input must be 3x3 matrix!".into());
     }
 


### PR DESCRIPTION
At the time of writing `get_dim()`, I thought `usize` is handy because the user anyway needs to convert to `usize` if it returns `i32`. But, after some thinking, I now feel it might not be always the case when the dim can be used as it is. For example, nalgebra takes two `usize` instead of a slice, so the allocation of the vector is not necessary.

```rust
/// @export
#[savvy]
fn nalgebra_input(x: RealSexp) -> savvy::Result<()> {
    let dim = x.get_dim().ok_or("no dimension found")?;

    if dim.len() != 2 {
        return Err("Input must be matrix!".into());
    }

    let m = DMatrix::from_vec(dim[0], dim[1], x.to_vec());

    r_println!("{m:?}");

    Ok(())
}

```