### PR TITLE
Expose LogicalSexp::as_slice_raw()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### New Features
+
+* `LogicalSexp` and `OwnedLogicalSexp` now have `as_slice_raw()` method.  This
+    is an expert-only function which might be found useful when you really need
+    to distinguish NAs.
+
 ## [v0.2.18] (2024-03-11)
 
 ### Minor improvements

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -19,7 +19,10 @@ impl_common_sexp_ops!(LogicalSexp);
 impl_common_sexp_ops_owned!(OwnedLogicalSexp);
 
 impl LogicalSexp {
-    fn as_slice_raw(&self) -> &[i32] {
+    /// Returns the internal representation, `&[i32]`, not `&[bool]`. This is an
+    /// expert-only function which might be found useful when you really need to
+    /// distinguish NAs.
+    pub fn as_slice_raw(&self) -> &[i32] {
         unsafe { std::slice::from_raw_parts(LOGICAL(self.0), self.len()) }
     }
 
@@ -39,7 +42,10 @@ impl OwnedLogicalSexp {
         LogicalSexp(self.inner)
     }
 
-    fn as_slice_raw(&self) -> &[i32] {
+    /// Returns the internal representation, `&[i32]`, not `&[bool]`. This is an
+    /// expert-only function which might be found useful when you really need to
+    /// distinguish NAs.
+    pub fn as_slice_raw(&self) -> &[i32] {
         unsafe { std::slice::from_raw_parts(self.raw, self.len()) }
     }
 


### PR DESCRIPTION
I found this is needed to construct polars' `BooleanChunked` from `LogicalSexp`