### PR TITLE
Support consuming user-defined structs in input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@
 ### New features
 
 * `get_dim()` and `set_dim()` are now available also on `Sexp`.
+* Now savvy allows to consume the value behind an external pointer. i.e., `T`
+  instead of `&T` or `&mut T` as the argument. After getting consumed, the
+  pointer is null, so any function call on the already-consumed R object results
+  in an error.
+  
+  Example:
+
+  ```rust
+  struct Value {};
+  struct Wrapper { inner: Value }
+
+  #[savvy]
+  impl Value {
+    fn new() -> Self {
+      Self {}
+    }
+  }
+
+  #[savvy]
+  impl Wrapper {
+    fn new(value: Value) -> Self {
+      Self { inner: value }
+    }
+  }
+  ```
+
+  ```r
+  v <- Value$new()
+  w <- Wrapper$new(v)  # value is consumed here.
+
+  w <- Wrapper$new(v)
+  #> Error: This external pointer is already consumed or deleted
+  ```
 
 ## [v0.4.0] (2024-03-27)
 
@@ -16,21 +49,21 @@
   generates a constructor `Person()`, but now the constructor is available as
   `Person$new()`.
 
-```rust
-struct Person {
-    pub name: String,
-}
-
-/// @export
-#[savvy]
-impl Person {
-    fn new() -> Self {
-        Self {
-            name: "".to_string(),
-        }
-    }
-}
-```
+  ```rust
+  struct Person {
+      pub name: String,
+  }
+  
+  /// @export
+  #[savvy]
+  impl Person {
+      fn new() -> Self {
+          Self {
+              name: "".to_string(),
+          }
+      }
+  }
+  ```
 
 ### New features
 
@@ -58,26 +91,26 @@ impl Person {
 * Now user-defined struct can be used as an argument of `#[savvy]`-ed functions.
   It must be specified as `&Ty` or `&mut Ty`, not `Ty`. 
 
-Example:
-
-```rust
-struct Person {
-    pub name: String,
-}
-
-#[savvy]
-impl Person {
-    fn get_name(&self) -> savvy::Result<savvy::Sexp> {
-        let name = self.name.as_str();
-        name.try_into()
-    }
-}
-
-#[savvy]
-fn get_name_external(x: &Person) -> savvy::Result<savvy::Sexp> {
-    x.get_name()
-}
-```
+  Example:
+  
+  ```rust
+  struct Person {
+      pub name: String,
+  }
+  
+  #[savvy]
+  impl Person {
+      fn get_name(&self) -> savvy::Result<savvy::Sexp> {
+          let name = self.name.as_str();
+          name.try_into()
+      }
+  }
+  
+  #[savvy]
+  fn get_name_external(x: &Person) -> savvy::Result<savvy::Sexp> {
+      x.get_name()
+  }
+  ```
 
 ### Fixed bugs
 

--- a/R-package/R/wrappers.R
+++ b/R-package/R/wrappers.R
@@ -68,6 +68,13 @@ abs_complex <- function(x) {
 }
 
 
+new_value_pair <- function(a, b) {
+  a <- .savvy_extract_ptr(a, "Value")
+  b <- .savvy_extract_ptr(b, "Value")
+  .savvy_wrap_ValuePair(.Call(new_value_pair__impl, a, b))
+}
+
+
 scalar_input_int <- function(x) {
   invisible(.Call(scalar_input_int__impl, x))
 }
@@ -324,6 +331,70 @@ set_name_external <- function(x, name) {
   invisible(.Call(set_name_external__impl, x, name))
 }
 
+
+Value <- new.env(parent = emptyenv())
+Value$new <- function(x) {
+  .savvy_wrap_Value(.Call(Value_new__impl, x))
+}
+
+
+.savvy_wrap_Value <- function(ptr) {
+  e <- new.env(parent = emptyenv())
+  e$.ptr <- ptr
+  e$pair <- Value_pair(ptr)
+  e$get <- Value_get(ptr)
+
+  class(e) <- "Value"
+  e
+}
+
+
+Value_pair <- function(self) {
+  function(b) {
+    b <- .savvy_extract_ptr(b, "Value")
+  .savvy_wrap_ValuePair(.Call(Value_pair__impl, self, b))
+  }
+}
+
+Value_get <- function(self) {
+  function() {
+  .Call(Value_get__impl, self)
+  }
+}
+
+
+
+ValuePair <- new.env(parent = emptyenv())
+ValuePair$new <- function(a, b) {
+  a <- .savvy_extract_ptr(a, "Value")
+  b <- .savvy_extract_ptr(b, "Value")
+  .savvy_wrap_ValuePair(.Call(ValuePair_new__impl, a, b))
+}
+
+ValuePair$new_copy <- function(a, b) {
+  a <- .savvy_extract_ptr(a, "Value")
+  b <- .savvy_extract_ptr(b, "Value")
+  .savvy_wrap_ValuePair(.Call(ValuePair_new_copy__impl, a, b))
+}
+
+
+.savvy_wrap_ValuePair <- function(ptr) {
+  e <- new.env(parent = emptyenv())
+  e$.ptr <- ptr
+  e$print <- ValuePair_print(ptr)
+
+  class(e) <- "ValuePair"
+  e
+}
+
+
+ValuePair_print <- function(self) {
+  function() {
+  invisible(.Call(ValuePair_print__impl, self))
+  }
+}
+
+
 #' A person with a name
 #'
 #' @export
@@ -341,7 +412,7 @@ Person$new_with_name <- function(name) {
 }
 
 Person$associated_function <- function() {
-  .Call(Person_associated_function__impl)
+.Call(Person_associated_function__impl)
 }
 
 
@@ -365,13 +436,13 @@ Person_another_person <- function(self) {
 
 Person_set_name <- function(self) {
   function(name) {
-    invisible(.Call(Person_set_name__impl, self, name))
+  invisible(.Call(Person_set_name__impl, self, name))
   }
 }
 
 Person_name <- function(self) {
   function() {
-    .Call(Person_name__impl, self)
+  .Call(Person_name__impl, self)
   }
 }
 
@@ -392,7 +463,7 @@ Person2 <- new.env(parent = emptyenv())
 
 Person2_name <- function(self) {
   function() {
-    .Call(Person2_name__impl, self)
+  .Call(Person2_name__impl, self)
   }
 }
 

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -88,6 +88,41 @@ SEXP abs_complex__impl(SEXP x) {
     return handle_result(res);
 }
 
+SEXP new_value_pair__impl(SEXP a, SEXP b) {
+    SEXP res = new_value_pair(a, b);
+    return handle_result(res);
+}
+
+SEXP Value_new__impl(SEXP x) {
+    SEXP res = Value_new(x);
+    return handle_result(res);
+}
+
+SEXP Value_pair__impl(SEXP self__, SEXP b) {
+    SEXP res = Value_pair(self__, b);
+    return handle_result(res);
+}
+
+SEXP Value_get__impl(SEXP self__) {
+    SEXP res = Value_get(self__);
+    return handle_result(res);
+}
+
+SEXP ValuePair_new__impl(SEXP a, SEXP b) {
+    SEXP res = ValuePair_new(a, b);
+    return handle_result(res);
+}
+
+SEXP ValuePair_new_copy__impl(SEXP a, SEXP b) {
+    SEXP res = ValuePair_new_copy(a, b);
+    return handle_result(res);
+}
+
+SEXP ValuePair_print__impl(SEXP self__) {
+    SEXP res = ValuePair_print(self__);
+    return handle_result(res);
+}
+
 SEXP scalar_input_int__impl(SEXP x) {
     SEXP res = scalar_input_int(x);
     return handle_result(res);
@@ -357,6 +392,13 @@ static const R_CallMethodDef CallEntries[] = {
     {"new_complex__impl", (DL_FUNC) &new_complex__impl, 1},
     {"first_complex__impl", (DL_FUNC) &first_complex__impl, 1},
     {"abs_complex__impl", (DL_FUNC) &abs_complex__impl, 1},
+    {"new_value_pair__impl", (DL_FUNC) &new_value_pair__impl, 2},
+    {"Value_new__impl", (DL_FUNC) &Value_new__impl, 1},
+    {"Value_pair__impl", (DL_FUNC) &Value_pair__impl, 2},
+    {"Value_get__impl", (DL_FUNC) &Value_get__impl, 1},
+    {"ValuePair_new__impl", (DL_FUNC) &ValuePair_new__impl, 2},
+    {"ValuePair_new_copy__impl", (DL_FUNC) &ValuePair_new_copy__impl, 2},
+    {"ValuePair_print__impl", (DL_FUNC) &ValuePair_print__impl, 1},
     {"scalar_input_int__impl", (DL_FUNC) &scalar_input_int__impl, 1},
     {"scalar_input_usize__impl", (DL_FUNC) &scalar_input_usize__impl, 1},
     {"scalar_input_real__impl", (DL_FUNC) &scalar_input_real__impl, 1},

--- a/R-package/src/rust/api.h
+++ b/R-package/src/rust/api.h
@@ -9,6 +9,7 @@ SEXP set_attr_int(SEXP attr, SEXP value);
 SEXP new_complex(SEXP size);
 SEXP first_complex(SEXP x);
 SEXP abs_complex(SEXP x);
+SEXP new_value_pair(SEXP a, SEXP b);
 SEXP scalar_input_int(SEXP x);
 SEXP scalar_input_usize(SEXP x);
 SEXP scalar_input_real(SEXP x);
@@ -52,6 +53,16 @@ SEXP list_with_names_and_values(void);
 SEXP external_person_new(void);
 SEXP get_name_external(SEXP x);
 SEXP set_name_external(SEXP x, SEXP name);
+
+// methods and associated functions for Value
+SEXP Value_new(SEXP x);
+SEXP Value_pair(SEXP self__, SEXP b);
+SEXP Value_get(SEXP self__);
+
+// methods and associated functions for ValuePair
+SEXP ValuePair_new(SEXP a, SEXP b);
+SEXP ValuePair_new_copy(SEXP a, SEXP b);
+SEXP ValuePair_print(SEXP self__);
 
 // methods and associated functions for Person
 SEXP Person_new(void);

--- a/R-package/src/rust/src/consuming_type.rs
+++ b/R-package/src/rust/src/consuming_type.rs
@@ -1,0 +1,51 @@
+use savvy::{r_println, savvy, Sexp};
+
+#[derive(Clone, Debug)]
+struct Value(i32);
+
+#[savvy]
+impl Value {
+    fn new(x: i32) -> Self {
+        Self(x)
+    }
+
+    // TODO: allow consuming self?
+    fn pair(&self, b: Value) -> savvy::Result<ValuePair> {
+        Ok(ValuePair { a: self.clone(), b })
+    }
+
+    fn get(&self) -> savvy::Result<Sexp> {
+        self.0.try_into()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct ValuePair {
+    a: Value,
+    b: Value,
+}
+
+#[savvy]
+impl ValuePair {
+    fn new(a: Value, b: Value) -> Self {
+        Self { a, b }
+    }
+
+    fn new_copy(a: &Value, b: &Value) -> Self {
+        Self {
+            a: a.clone(),
+            b: b.clone(),
+        }
+    }
+
+    fn print(&self) -> savvy::Result<()> {
+        r_println!("{:?}", self);
+        Ok(())
+    }
+}
+
+#[savvy]
+fn new_value_pair(a: Value, b: Value) -> savvy::Result<ValuePair> {
+    Ok(ValuePair { a, b })
+}

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -21,6 +21,9 @@ pub use function::*;
 mod complex;
 pub use complex::*;
 
+mod consuming_type;
+pub use consuming_type::*;
+
 use savvy::{r_print, savvy, OwnedListSexp};
 
 use savvy::{

--- a/R-package/tests/testthat/_snaps/consuming_types.md
+++ b/R-package/tests/testthat/_snaps/consuming_types.md
@@ -1,0 +1,28 @@
+# consuming types work
+
+    Code
+      x1$print()
+    Output
+      ValuePair { a: Value(1), b: Value(2) }
+
+---
+
+    Code
+      x2$print()
+    Output
+      ValuePair { a: Value(1), b: Value(2) }
+
+---
+
+    Code
+      x3$print()
+    Output
+      ValuePair { a: Value(10), b: Value(20) }
+
+---
+
+    Code
+      x4$print()
+    Output
+      ValuePair { a: Value(10), b: Value(20) }
+

--- a/R-package/tests/testthat/test-consuming_types.R
+++ b/R-package/tests/testthat/test-consuming_types.R
@@ -1,0 +1,41 @@
+test_that("consuming types work", {
+  a <- Value$new(1L)
+  b <- Value$new(2L)
+  expect_equal(a$get(), 1L)
+  expect_equal(b$get(), 2L)
+
+  # not consumed
+  x1 <- ValuePair$new_copy(a, b)
+  expect_snapshot(x1$print())
+
+  # since they are not consumed, they still can return value
+  expect_equal(a$get(), 1L)
+  expect_equal(b$get(), 2L)
+
+  # consumed
+  x2 <- ValuePair$new(a, b)
+  expect_snapshot(x2$print())
+
+  # since they are consumed, this returns an error
+  expect_error(a$get())
+  expect_error(b$get())
+
+  # method
+
+  a3 <- Value$new(10L)
+  b3 <- Value$new(20L)
+  x3 <- a3$pair(b3)
+  expect_snapshot(x3$print())
+  # TODO
+  # expect_error(a3$get())
+  expect_error(b3$get())
+
+  # bare function
+
+  a4 <- Value$new(10L)
+  b4 <- Value$new(20L)
+  x4 <- new_value_pair(a4, b4)
+  expect_snapshot(x4$print())
+  expect_error(a4$get())
+  expect_error(b4$get())
+})

--- a/R-package/tests/testthat/test-invalid_pointer.R
+++ b/R-package/tests/testthat/test-invalid_pointer.R
@@ -6,5 +6,5 @@ test_that("invalid pointer doesn't clash the session", {
   saveRDS(x, rds_file)
 
   x <- readRDS(rds_file)
-  expect_error(x$name(), "Invalid external pointer")
+  expect_error(x$name(), "This external pointer is already consumed or deleted")
 })

--- a/savvy-bindgen/src/savvy_fn.rs
+++ b/savvy-bindgen/src/savvy_fn.rs
@@ -12,7 +12,8 @@ pub struct ParsedResult {
 enum SavvyInputTypeCategory {
     SexpWrapper,
     PrimitiveType,
-    UserDefinedType,
+    UserDefinedTypeRef, // &T
+    UserDefinedType,    // T
 }
 
 struct SavvyInputType {
@@ -38,7 +39,7 @@ impl SavvyInputType {
                         })
                     } else {
                         Ok(Self {
-                            category: SavvyInputTypeCategory::UserDefinedType,
+                            category: SavvyInputTypeCategory::UserDefinedTypeRef,
                             ty_orig: ty.clone(),
                             ty_str,
                         })
@@ -56,8 +57,8 @@ impl SavvyInputType {
                 let ty_str = type_ident.to_string();
                 match ty_str.as_str() {
                     // Owned-types are not allowed for the input
-                    "OwnedIntegerSexp" | "OwnedRealSexp" | "OwnedComplexSexp" | "OwnedLogicalSexp"
-                    | "OwnedStringSexp" | "OwnedListSexp" => {
+                    "OwnedIntegerSexp" | "OwnedRealSexp" | "OwnedComplexSexp"
+                    | "OwnedLogicalSexp" | "OwnedStringSexp" | "OwnedListSexp" => {
                         let msg = format!(
                             "`Owned-` types are not allowed here. Did you mean `{}`?",
                             ty_str.strip_prefix("Owned").unwrap()
@@ -66,24 +67,25 @@ impl SavvyInputType {
                     }
 
                     // Read-only types
-                    "Sexp" | "IntegerSexp" | "RealSexp" | "ComplexSexp" | "LogicalSexp" | "StringSexp"
-                    | "ListSexp" | "FunctionSexp" => Ok(Self {
+                    "Sexp" | "IntegerSexp" | "RealSexp" | "ComplexSexp" | "LogicalSexp"
+                    | "StringSexp" | "ListSexp" | "FunctionSexp" => Ok(Self {
                         category: SavvyInputTypeCategory::SexpWrapper,
                         ty_orig: ty.clone(),
-                    ty_str
-                }),
+                        ty_str,
+                    }),
 
                     // Primitive types
                     "i32" | "usize" | "f64" | "bool" => Ok(Self {
                         category: SavvyInputTypeCategory::PrimitiveType,
                         ty_orig: ty.clone(),
-                    ty_str
-                }),
+                        ty_str,
+                    }),
 
-                    _ => Err(syn::Error::new_spanned(
-                        type_path,
-                        format!("A user-defined struct must be in the form of either `&{ty_str}` or `&mut {ty_str}`"),
-                    )),
+                    _ => Ok(Self {
+                        category: SavvyInputTypeCategory::UserDefinedType,
+                        ty_orig: ty.clone(),
+                        ty_str,
+                    }),
                 }
             }
             _ => Err(syn::Error::new_spanned(
@@ -95,11 +97,7 @@ impl SavvyInputType {
 
     /// Return the corresponding type for internal function.
     fn to_rust_type_outer(&self) -> syn::Type {
-        match &self.category {
-            SavvyInputTypeCategory::SexpWrapper => self.ty_orig.clone(),
-            SavvyInputTypeCategory::PrimitiveType => self.ty_orig.clone(),
-            SavvyInputTypeCategory::UserDefinedType => self.ty_orig.clone(),
-        }
+        self.ty_orig.clone()
     }
 
     /// Return the corresponding type for API function (at the moment, only `SEXP` is supported).
@@ -124,7 +122,10 @@ impl SavvyFnArg {
     }
 
     pub fn is_user_defined_type(&self) -> bool {
-        matches!(&self.ty.category, SavvyInputTypeCategory::UserDefinedType)
+        matches!(
+            &self.ty.category,
+            SavvyInputTypeCategory::UserDefinedTypeRef | SavvyInputTypeCategory::UserDefinedType
+        )
     }
 
     pub fn pat_string(&self) -> String {

--- a/savvy-macro/tests/cases/simple_cases.rs
+++ b/savvy-macro/tests/cases/simple_cases.rs
@@ -28,11 +28,4 @@ fn wrong_type_owned_string(x: OwnedStringSexp) -> savvy::Result<()> {
     Ok(())
 }
 
-struct Foo;
-
-#[savvy]
-fn wrong_type_custom_type_no_ref(x: Foo) -> savvy::Result<()> {
-    Ok(())
-}
-
 fn main() {}

--- a/savvy-macro/tests/cases/simple_cases.stderr
+++ b/savvy-macro/tests/cases/simple_cases.stderr
@@ -35,9 +35,3 @@ error: `Owned-` types are not allowed here. Did you mean `StringSexp`?
    |
 27 | fn wrong_type_owned_string(x: OwnedStringSexp) -> savvy::Result<()> {
    |                               ^^^^^^^^^^^^^^^
-
-error: A user-defined struct must be in the form of either `&Foo` or `&mut Foo`
-  --> tests/cases/simple_cases.rs:34:37
-   |
-34 | fn wrong_type_custom_type_no_ref(x: Foo) -> savvy::Result<()> {
-   |                                     ^^^

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,9 @@ impl std::fmt::Display for Error {
             Error::UnexpectedType(type_name) => write!(f, "Unexpected type: {}", type_name),
             Error::NotScalar => write!(f, "Must be length 1 of non-missing value"),
             Error::Aborted(_) => write!(f, "Aborted due to some error"),
-            Error::InvalidPointer => write!(f, "Invalid external pointer"),
+            Error::InvalidPointer => {
+                write!(f, "This external pointer is already consumed or deleted")
+            }
             Error::GeneralError(msg) => write!(f, "{}", msg),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,9 @@ pub mod unwind_protect;
 use std::os::raw::c_char;
 
 pub use error::{Error, Result};
-pub use sexp::external_pointer::{get_external_pointer_addr, ExternalPointerSexp, IntoExtPtrSexp};
+pub use sexp::external_pointer::{
+    get_external_pointer_addr, take_external_pointer_value, ExternalPointerSexp, IntoExtPtrSexp,
+};
 pub use sexp::function::{FunctionArgs, FunctionCallResult, FunctionSexp};
 pub use sexp::integer::{IntegerSexp, OwnedIntegerSexp};
 pub use sexp::list::{ListSexp, OwnedListSexp};


### PR DESCRIPTION
Close #128

Example:

```rust
struct Value(i32);

#[savvy]
impl Value {
    fn new(x: i32) -> Self {
        Self(x)
    }
}

struct ValuePair {
    a: Value,
    b: Value,
}

#[savvy]
impl ValuePair {
    fn new(a: Value, b: Value) -> Self {
        Self { a, b }
    }
    fn print(&self) -> savvy::Result<()> {
        // ...snip...
    }
}
```

``` r
a <- Value$new(1L)
b <- Value$new(2L)

pair <- ValuePair$new(a, b)  # a and b are consumed
pair$print()
#> ValuePair { a: Value(1), b: Value(2) }

pair <- ValuePair$new(a, b)  # you cannot use a or b anymore
#> Error: This external pointer is already consumed or deleted
```