### PR TITLE
Optimize constructors for `LogicalSexp` and `StringSexp`

### DIFF
--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -63,20 +63,22 @@ impl OwnedLogicalSexp {
     pub fn set_elt(&mut self, i: usize, v: bool) -> crate::error::Result<()> {
         super::utils::assert_len(self.len, i)?;
 
-        unsafe {
-            SET_LOGICAL_ELT(self.inner, i as _, v as _);
-        }
+        unsafe { self.set_elt_unchecked(i as _, v as _) };
 
         Ok(())
+    }
+
+    /// Set the value of the `i`-th element.
+    /// Safety: the user has to assure bounds are checked.
+    unsafe fn set_elt_unchecked(&mut self, i: isize, v: i32) {
+        SET_LOGICAL_ELT(self.inner, i, v);
     }
 
     /// Set the `i`-th element to NA.
     pub fn set_na(&mut self, i: usize) -> crate::error::Result<()> {
         super::utils::assert_len(self.len, i)?;
 
-        unsafe {
-            SET_LOGICAL_ELT(self.inner, i as _, R_NaInt);
-        }
+        unsafe { self.set_elt_unchecked(i as _, R_NaInt) };
 
         Ok(())
     }
@@ -196,7 +198,8 @@ impl OwnedLogicalSexp {
         let x_slice = x.as_ref();
         let mut out = unsafe { Self::new_without_init(x_slice.len())? };
         for (i, v) in x_slice.iter().enumerate() {
-            out.set_elt(i, *v)?;
+            // Safety: slice and OwnedLogicalSexp have the same length.
+            unsafe { out.set_elt_unchecked(i as _, *v as _) };
         }
         Ok(out)
     }

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -68,9 +68,9 @@ impl OwnedLogicalSexp {
         Ok(())
     }
 
-    /// Set the value of the `i`-th element.
-    /// Safety: the user has to assure bounds are checked.
-    unsafe fn set_elt_unchecked(&mut self, i: isize, v: i32) {
+    // Set the value of the `i`-th element.
+    // Safety: the user has to assure bounds are checked.
+    pub(crate) unsafe fn set_elt_unchecked(&mut self, i: isize, v: i32) {
         SET_LOGICAL_ELT(self.inner, i, v);
     }
 

--- a/src/sexp/mod.rs
+++ b/src/sexp/mod.rs
@@ -377,6 +377,8 @@ pub(crate) unsafe fn set_dim_to_sexp<T>(value: SEXP, dim: &[T]) -> crate::error:
 where
     T: TryInto<i32> + Copy,
 {
+    let dim_sexp: OwnedIntegerSexp =
+        OwnedIntegerSexp::try_from_slice::<&[i32]>(dim.try_into().unwrap_or_default())?;
     let mut dim_sexp = unsafe { OwnedIntegerSexp::new_without_init(dim.len())? };
     dim.iter()
         .enumerate()

--- a/src/sexp/mod.rs
+++ b/src/sexp/mod.rs
@@ -377,8 +377,6 @@ pub(crate) unsafe fn set_dim_to_sexp<T>(value: SEXP, dim: &[T]) -> crate::error:
 where
     T: TryInto<i32> + Copy,
 {
-    let dim_sexp: OwnedIntegerSexp =
-        OwnedIntegerSexp::try_from_slice::<&[i32]>(dim.try_into().unwrap_or_default())?;
     let mut dim_sexp = unsafe { OwnedIntegerSexp::new_without_init(dim.len())? };
     dim.iter()
         .enumerate()

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -68,9 +68,9 @@ impl OwnedStringSexp {
         Ok(())
     }
 
-    /// Set the value of the `i`-th element.
-    /// Safety: the user has to assure bounds are checked.
-    unsafe fn set_elt_unchecked(&mut self, i: isize, v: SEXP) {
+    // Set the value of the `i`-th element.
+    // Safety: the user has to assure bounds are checked.
+    pub(crate) unsafe fn set_elt_unchecked(&mut self, i: isize, v: SEXP) {
         SET_STRING_ELT(self.inner, i, v);
     }
 


### PR DESCRIPTION
Remove some bounds check on `LogicalSexp` and `StringSexp` constructors. I didn't mess with the iterator part since I don't know if you are finished there yet, but `set_elt_unchecked` can probably be used there as well.
I also removed a nested unsafe in one of your functions.
I can't manage to test your crate. I don't know how to... But it compiles.