### PR TITLE
Separate the implementation of `#[savvy]`'s TryFrom generation for a struct

### DIFF
--- a/R-package/src/rust/src/consuming_type.rs
+++ b/R-package/src/rust/src/consuming_type.rs
@@ -1,5 +1,6 @@
 use savvy::{r_println, savvy, Sexp};
 
+#[savvy]
 #[derive(Clone, Debug)]
 struct Value(i32);
 
@@ -19,6 +20,7 @@ impl Value {
 }
 
 #[allow(dead_code)]
+#[savvy]
 #[derive(Debug)]
 struct ValuePair {
     a: Value,

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -320,10 +320,12 @@ fn list_with_names_and_values() -> savvy::Result<savvy::Sexp> {
     out.into()
 }
 
+#[savvy]
 struct Person {
     pub name: String,
 }
 
+#[savvy]
 #[allow(dead_code)]
 struct Person2 {
     pub name: String,

--- a/savvy-bindgen/src/gen/templates/lib_rs
+++ b/savvy-bindgen/src/gen/templates/lib_rs
@@ -49,6 +49,7 @@ fn int_times_int(x: IntegerSexp, y: i32) -> savvy::Result<savvy::Sexp> {
     Ok(out.into())
 }
 
+#[savvy]
 struct Person {
     pub name: String,
 }

--- a/savvy-bindgen/src/lib.rs
+++ b/savvy-bindgen/src/lib.rs
@@ -2,6 +2,7 @@ mod gen;
 mod parse_file;
 mod savvy_fn;
 mod savvy_impl;
+mod savvy_struct;
 mod utils;
 
 pub use gen::c::{generate_c_header_file, generate_c_impl_file};
@@ -12,6 +13,7 @@ pub use gen::static_files::{
 };
 pub use savvy_fn::{ParsedResult, SavvyFn, SavvyFnArg, SavvyFnType};
 pub use savvy_impl::SavvyImpl;
+pub use savvy_struct::SavvyStruct;
 
 pub use utils::extract_docs;
 

--- a/savvy-bindgen/src/savvy_struct.rs
+++ b/savvy-bindgen/src/savvy_struct.rs
@@ -1,0 +1,102 @@
+use syn::{parse_quote, ItemStruct};
+
+use crate::extract_docs;
+
+pub struct SavvyStruct {
+    /// Doc comments
+    pub docs: Vec<String>,
+    /// Attributes except for `#[savvy]`
+    pub attrs: Vec<syn::Attribute>,
+    /// Original struct name
+    pub ty: syn::Ident,
+    /// Original code
+    pub orig: ItemStruct,
+}
+
+impl SavvyStruct {
+    pub fn new(orig: &syn::ItemStruct) -> syn::Result<Self> {
+        let mut attrs = orig.attrs.clone();
+        // Remove #[savvy]
+        attrs.retain(|attr| attr != &parse_quote!(#[savvy]));
+        // Extract doc comments
+        let docs = extract_docs(attrs.as_slice());
+        let ty = orig.ident.clone();
+
+        Ok(Self {
+            docs,
+            attrs,
+            ty,
+            orig: orig.clone(),
+        })
+    }
+
+    pub fn generate_try_from_impls(&self) -> Vec<syn::ItemImpl> {
+        let ty = self.ty.clone();
+
+        let impl_into_external_pointer: syn::ItemImpl =
+            parse_quote!(impl savvy::IntoExtPtrSexp for #ty {});
+
+        let impl_try_from_ty_to_sexp: syn::ItemImpl = parse_quote!(
+            impl TryFrom<#ty> for savvy::Sexp {
+                type Error = savvy::Error;
+
+                fn try_from(value: #ty) -> savvy::Result<Self> {
+                    use savvy::IntoExtPtrSexp;
+
+                    Ok(value.into_external_pointer())
+                }
+            }
+        );
+
+        let impl_try_from_sexp_to_ref_ty: syn::ItemImpl = parse_quote!(
+            impl TryFrom<savvy::Sexp> for &#ty {
+                type Error = savvy::Error;
+
+                fn try_from(value: savvy::Sexp) -> savvy::Result<Self> {
+                    // Return error if the SEXP is not an external pointer
+                    value.assert_external_pointer()?;
+
+                    let x = unsafe { savvy::get_external_pointer_addr(value.0)? as *mut #ty };
+                    let res = unsafe { x.as_ref() };
+                    res.ok_or("Failed to convert the external pointer to the Rust object".into())
+                }
+            }
+        );
+
+        let impl_try_from_sexp_to_ref_mut_ty: syn::ItemImpl = parse_quote!(
+            impl TryFrom<savvy::Sexp> for &mut #ty {
+                type Error = savvy::Error;
+
+                fn try_from(value: savvy::Sexp) -> savvy::Result<Self> {
+                    // Return error if the SEXP is not an external pointer
+                    value.assert_external_pointer()?;
+
+                    let x = unsafe { savvy::get_external_pointer_addr(value.0)? as *mut #ty };
+                    let res = unsafe { x.as_mut() };
+                    res.ok_or("Failed to convert the external pointer to the Rust object".into())
+                }
+            }
+        );
+
+        let impl_try_from_sexp_to_ty: syn::ItemImpl = parse_quote!(
+            impl TryFrom<savvy::Sexp> for #ty {
+                type Error = savvy::Error;
+
+                fn try_from(value: savvy::Sexp) -> savvy::Result<Self> {
+                    // Return error if the SEXP is not an external pointer
+                    value.assert_external_pointer()?;
+
+                    unsafe { savvy::take_external_pointer_value::<#ty>(value.0) }
+                }
+            }
+        );
+
+        vec![
+            impl_into_external_pointer,
+            impl_try_from_ty_to_sexp,
+            impl_try_from_sexp_to_ref_ty,
+            impl_try_from_sexp_to_ref_mut_ty,
+            impl_try_from_sexp_to_ty,
+        ]
+    }
+}


### PR DESCRIPTION
This is a first step towards #118 and #149 

``` rust
#[savvy]   // NEW
struct Person {
    pub name: String,
}

#[savvy]
impl Person {
```