### PR TITLE
unsafe methods to set name and values of ListSexp

### DIFF
--- a/src/sexp/list.rs
+++ b/src/sexp/list.rs
@@ -43,7 +43,9 @@ impl ListSexp {
         Some(unsafe { self.get_by_index_unchecked(i) })
     }
 
-    // Safety: the user has to assure bounds are checked.
+    /// # Safety
+    ///
+    /// The user has to assure bounds are checked.
     pub unsafe fn get_by_index_unchecked(&self, i: usize) -> Sexp {
         unsafe {
             let e = VECTOR_ELT(self.0, i as _);
@@ -112,7 +114,9 @@ impl OwnedListSexp {
         self.values.get_by_index(i)
     }
 
-    // Safety: the user has to assure bounds are checked.
+    /// # Safety
+    ///
+    /// The user has to assure bounds are checked.
     pub unsafe fn get_by_index_unchecked(&self, i: usize) -> Sexp {
         unsafe { self.values.get_by_index_unchecked(i) }
     }
@@ -142,7 +146,9 @@ impl OwnedListSexp {
         Ok(())
     }
 
-    // Safety: the user has to assure bounds are checked.
+    /// # Safety
+    ///
+    /// The user has to assure bounds are checked.
     #[inline]
     pub unsafe fn set_value_unchecked(&mut self, i: usize, v: SEXP) {
         unsafe { SET_VECTOR_ELT(self.values.inner(), i as _, v) };
@@ -161,7 +167,9 @@ impl OwnedListSexp {
         Ok(())
     }
 
-    // Safety: the user has to assure bounds are checked.
+    /// # Safety
+    ///
+    /// The user has to assure bounds are checked.
     #[inline]
     pub unsafe fn set_name_unchecked(&mut self, i: usize, k: SEXP) {
         if let Some(names) = self.names.as_mut() {

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -71,7 +71,7 @@ impl OwnedStringSexp {
     // Set the value of the `i`-th element.
     // Safety: the user has to assure bounds are checked.
     #[inline]
-    unsafe fn set_elt_unchecked(&mut self, i: usize, v: SEXP) {
+    pub(crate) unsafe fn set_elt_unchecked(&mut self, i: usize, v: SEXP) {
         unsafe { SET_STRING_ELT(self.inner, i as _, v) };
     }
 
@@ -187,7 +187,7 @@ impl OwnedStringSexp {
     }
 }
 
-unsafe fn str_to_charsxp(v: &str) -> crate::error::Result<SEXP> {
+pub(crate) unsafe fn str_to_charsxp(v: &str) -> crate::error::Result<SEXP> {
     unsafe {
         // We might be able to put `R_NaString` directly without using
         // <&str>::na(), but probably this is an inevitable cost of


### PR DESCRIPTION
Added 2 unsafe methods. This time I decided to make them public as it seems to be the better way in the case of `ListSexp`, since there are no constructors from slices (and I think it's better not to have them in this case).
I also signaled as unsafe other "unchecked" functions.
Please feel free to criticize and change the code at your will.