### PR TITLE
Catch panic

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run cargo test
         run: |
-          cargo test --manifest-path=./savvy-macro/Cargo.toml
+          # cargo test --manifest-path=./savvy-macro/Cargo.toml
           cargo test --manifest-path=./savvy-bindgen/Cargo.toml
           cargo r-test
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,6 +11,9 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
+    defaults:
+      run:
+        shell: bash
 
     name: "${{ matrix.config.os }} (R: ${{ matrix.config.r }}, rust: ${{ matrix.config.rust }})"
 
@@ -83,7 +86,6 @@ jobs:
           mv savvy-macro/ ./R-package/src/savvy/
           mv savvy-bindgen/ ./R-package/src/savvy/
           mv savvy-ffi/ ./R-package/src/savvy/
-        shell: bash
 
       - name: Run cargo test of the R package
         run: cargo test --manifest-path=./R-package/src/rust/Cargo.toml

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
   
-      - uses: dtolnay/rust-toolchain@1.64.0
+      - uses: dtolnay/rust-toolchain@1.65.0
       
       - name: Build
         run: cargo build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### New features
+
+* Now savvy's debug build (when `DEBUG` envvar is set to `true`, i.e.,
+  `devtools::load_all()`), panic doesn't crash R session and shows bactrace.
+  This is useful for investigating what's the cause of the panic.
+
+  Please keep in mind that, in Rust, panic is an **unrecoverable error**. So,
+  not crashing doesn't mean you are saved.
+
 ## [v0.5.1] (2024-04-13)
 
 ### New features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 exclude = ["/book", "/R-package", "README.qmd"]
 
 # Determined by `cargo msrv`
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 
 [dependencies]
 savvy-ffi = { version = "0.5.1", path = "./savvy-ffi" }

--- a/R-package/tests/testthat/test-panic.R
+++ b/R-package/tests/testthat/test-panic.R
@@ -1,0 +1,17 @@
+# test_that("panic doesn't crash R session", {
+#   code <- r"(
+# use savvy::savvy;
+#
+# #[allow(unreachable_code)]
+# #[savvy]
+# fn try_panic() -> savvy::Result<()> {
+#    panic!("safe");
+#    Ok(())
+# }
+# )"
+#
+#   savvy_override <- list(savvy = list(path = file.path(getwd(), "../../../")))
+#   savvy::savvy_source(code, use_cache_dir = TRUE, dependencies = savvy_override)
+#
+#   expect_error(try_panic())
+# })

--- a/savvy-bindgen/src/gen/rust.rs
+++ b/savvy-bindgen/src/gen/rust.rs
@@ -113,7 +113,12 @@ impl SavvyFn {
 
         let orig_body = &mut out.block;
         let new_body: syn::Block = parse_quote!({
+            let orig_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(savvy::panic_hook::panic_hook));
+
             let result = std::panic::catch_unwind(|| #orig_body);
+
+            std::panic::set_hook(orig_hook);
 
             match result {
                 Ok(orig_result) => orig_result,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 pub mod error;
 pub mod ffi;
 pub mod io;
+pub mod panic_hook;
 pub mod protect;
 pub mod sexp;
 pub mod unwind_protect;

--- a/src/panic_hook.rs
+++ b/src/panic_hook.rs
@@ -1,0 +1,35 @@
+pub fn panic_hook(panic_info: &std::panic::PanicInfo) {
+    // Forcibly captures a full backtrace regardless of RUST_BACKTRACE
+    let bt = std::backtrace::Backtrace::force_capture().to_string();
+
+    // Since savvy generates many wrappers, the backtrace is boringly deep. Try
+    // cutting the uninteresting part.
+    let bt_short = bt
+        .lines()
+        .skip_while(|line| !line.contains("std::panic::catch_unwind"))
+        // C stacks are not visible from Rust's side and shown as `<unknown>`.
+        .take_while(|line| !line.contains("<unknown>"))
+        .collect::<Vec<&str>>()
+        .join("\n");
+
+    let bt = if bt_short.is_empty() { bt } else { bt_short };
+
+    crate::io::r_eprint(
+        &format!(
+            "panic occured!
+
+Original message:
+{panic_info}
+
+Backtrace:
+
+...snip... (frames of savvy framework)
+
+{bt}
+
+...snip... (frames of R)
+"
+        ),
+        true,
+    );
+}


### PR DESCRIPTION
Address #163 

In release build, `catch_unwind()` catches unwinding before the FFI boundary and aborts. Note that, while `panic!` should terminate the process in principle, it might be safe to throw R error and restart unwinding on R's side rather than aborting. But, I cannot make my mind at the moment.

In debug build (with `DEBUG=true`, i.e. in `devtools::load_all(".")`), panic no longer crashes the R session. It shows backtrace.

``` r
code <- r"(
use savvy::savvy;

#[allow(unreachable_code)]
#[savvy]
fn try_panic() -> savvy::Result<()> {
   panic!("safe");
   Ok(())
}
)"

savvy_override <- list(savvy = list(git = "https://github.com/yutannihilation/savvy", branch = "catch-panic"))
savvy::savvy_source(code, use_cache_dir = TRUE, dependencies = savvy_override)


try_panic()
#> panic occured!
#> 
#> Original message:
#> panicked at src\lib.rs:7:4:
#> safe
#> 
#> Backtrace:
#> 
#> ...snip... (frames of savvy framework)
#> 
#>   16: std::panic::catch_unwind
#>              at /rustc/7cf61ebde7b22796c69757901dd346d0fe70bd97\library\std\src/panic.rs:142:14
#>   17: savvy_temporary_package2::savvy_try_panic_inner
#>              at C:\Users\Yutani\AppData\Local\R\cache\R\savvy\R-package\src\rust\src\lib.rs:5:1
#>   18: try_panic
#>              at C:\Users\Yutani\AppData\Local\R\cache\R\savvy\R-package\src\rust\src\lib.rs:5:1
#>   19: try_panic__impl
#>              at C:\Users\Yutani\AppData\Local\R\cache\R\savvy\R-package\src\init.c:36:16
#> 
#> ...snip... (frames of R)
#> 
#> Error: panic happened
```