### PR TITLE
Fix try_from_iter()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   Please keep in mind that, in Rust, panic is an **unrecoverable error**. So,
   not crashing doesn't mean you are saved.
 
+### Fixed bugs
+
+* Fixed a bug in `try_from_iter()` when the actual length is different than the
+  size reported by `size_hint()`.
+
 ## [v0.5.1] (2024-04-13)
 
 ### New features

--- a/src/sexp/complex.rs
+++ b/src/sexp/complex.rs
@@ -153,10 +153,12 @@ impl OwnedComplexSexp {
                     last_index = i;
                 }
 
-                if last_index + 1 != upper {
+                let new_len = last_index + 1;
+                if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, (last_index + 1) as _);
+                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
                     }
+                    out.len = new_len;
                 }
 
                 Ok(out)

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -193,10 +193,12 @@ impl OwnedIntegerSexp {
                     last_index = i;
                 }
 
-                if last_index + 1 != upper {
+                let new_len = last_index + 1;
+                if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, (last_index + 1) as _);
+                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
                     }
+                    out.len = new_len;
                 }
 
                 Ok(out)

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -178,10 +178,12 @@ impl OwnedLogicalSexp {
                     last_index = i;
                 }
 
-                if last_index + 1 != upper {
+                let new_len = last_index + 1;
+                if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, (last_index + 1) as _);
+                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
                     }
+                    out.len = new_len;
                 }
 
                 Ok(out)

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -179,10 +179,12 @@ impl OwnedRealSexp {
                     last_index = i;
                 }
 
-                if last_index + 1 != upper {
+                let new_len = last_index + 1;
+                if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, (last_index + 1) as _);
+                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
                     }
+                    out.len = new_len;
                 }
 
                 Ok(out)

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -127,10 +127,12 @@ impl OwnedStringSexp {
                     last_index = i;
                 }
 
-                if last_index + 1 != upper {
+                let new_len = last_index + 1;
+                if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, (last_index + 1) as _);
+                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
                     }
+                    out.len = new_len;
                 }
 
                 Ok(out)


### PR DESCRIPTION
`try_from_iter()` doesn't change the `len` stored in Rust's side. This PR fixes it. Tests will be added in the doctest later...