### PR TITLE
Make savvy-cli use the local code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Fixed a bug in `try_from_iter()` when the actual length is different than the
   size reported by `size_hint()`.
 
+* `savvy-cli test` now uses the local crate as the path dependency, instead of
+  using the savvy crate fixedly.
+
 ## [v0.5.1] (2024-04-13)
 
 ### New features

--- a/savvy-macro/Cargo.toml
+++ b/savvy-macro/Cargo.toml
@@ -26,8 +26,3 @@ insta = { version = "1.38.0", features = ["yaml"] }
 
 [package.metadata.dist]
 dist = false
-
-# c.f. https://insta.rs/docs/quickstart/#optional-faster-runs
-[profile.dev.package]
-insta.opt-level = 3
-similar.opt-level = 3


### PR DESCRIPTION
Pass `dependencies` variable to `savvy::savvy_source()`