### PR TITLE
Minor improvements about CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   `Cargo.toml` with a release profile of `panic = "abort"`. You need to modify
   this setting if you really want to catch panics on the release build.
 
+* `savvy-cli update` now ensures `.Rbuildignore` contains `^src/rust/.cargo$`
+  and `^src/rust/target$`.
+
+
 ## [v0.5.2] (2024-04-14)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 * `savvy-cli update` now ensures `.Rbuildignore` contains `^src/rust/.cargo$`
   and `^src/rust/target$`.
 
+* `savvy-cli test` now uses OS's cache dir instead of the `.savvy` directory.
+
+### Fixed bugs
+
+* Now `savvy-cli test` works for other crates than savvy.
 
 ## [v0.5.2] (2024-04-14)
 

--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -4,7 +4,7 @@
 ^README\.Rmd$
 ^\.github$
 
-^src/.cargo$
 ^src/rust/.cargo$
 ^src/rust/.vscode$
 ^src/rust/target$
+

--- a/book/src/get_started.md
+++ b/book/src/get_started.md
@@ -67,6 +67,7 @@ After `savvy::savvy_init()`, the structure of your R package should look like be
 
 ```
 .
+├── .Rbuildignore
 ├── DESCRIPTION
 ├── NAMESPACE
 ├── R

--- a/savvy-cli/Cargo.toml
+++ b/savvy-cli/Cargo.toml
@@ -22,6 +22,7 @@ futures-lite = "2"
 savvy-bindgen = { version = "0", path = "../savvy-bindgen", features = [
     "use_formatter",
 ] }
+dirs = "5.0.1"
 
 [package.metadata.dist]
 dist = true

--- a/savvy-cli/src/main.rs
+++ b/savvy-cli/src/main.rs
@@ -408,12 +408,17 @@ async fn run_test(tests: String, crate_name: &str, crate_dir: &Path) -> std::io:
     let r_pkg_name = pkg.package_name_for_r();
 
     // Specify the crate to test as a path dependency.
+    let mut additional_deps = format!(r#"{crate_name} = {{ path = "../../../../" }}"#);
+    if crate_name != "savvy" {
+        additional_deps.push('\n');
+        additional_deps.push_str(r#"savvy ="*""#);
+    }
     write_file(
         &tmp_r_pkg_dir.join(PATH_CARGO_TOML),
         &generate_cargo_toml(
             &rust_pkg_name,
             // Cargo.toml is located at <crate dir>/.savvy/temporary-R-package-for-tests/src/rust/Cargo.toml
-            &format!(r#"{crate_name} = {{ path = "../../../../" }}"#),
+            &additional_deps,
         ),
     );
     // Since this can be within the workspace of a Rust package, clarify this is

--- a/savvy-cli/src/main.rs
+++ b/savvy-cli/src/main.rs
@@ -2,6 +2,7 @@ mod utils;
 use async_process::Stdio;
 use savvy_bindgen::generate_test_code;
 use savvy_bindgen::merge_parsed_results;
+use savvy_bindgen::read_file;
 use utils::*;
 
 use std::collections::VecDeque;
@@ -145,6 +146,7 @@ const PATH_GITIGNORE: &str = "src/.gitignore";
 const PATH_C_HEADER: &str = "src/rust/api.h";
 const PATH_C_IMPL: &str = "src/init.c";
 const PATH_R_IMPL: &str = "R/wrappers.R";
+const PATH_R_BUILDIGNORE: &str = ".Rbuildignore";
 
 fn get_pkg_metadata(path: &Path) -> PackageDescription {
     if !path.exists() {
@@ -256,6 +258,24 @@ fn parse_crate(lib_rs: &Path, crate_name: &str) -> Vec<ParsedResult> {
     parsed
 }
 
+fn tweak_r_buildignore(path: &Path) {
+    let ignores = ["^src/rust/.cargo$", "^src/rust/target$"];
+    let r_buildignore = path.join(PATH_R_BUILDIGNORE);
+    if !r_buildignore.exists() {
+        write_file(&r_buildignore, &format!("{}\n", ignores.join("\n")));
+    } else {
+        let content = read_file(&r_buildignore);
+        let rest = ignores
+            .into_iter()
+            .filter(|&i| !content.contains(i))
+            .collect::<Vec<&str>>()
+            .join("\n");
+        if !rest.is_empty() {
+            append_file(&r_buildignore, &format!("\n{rest}\n"));
+        }
+    }
+}
+
 fn update(path: &Path) {
     let pkg_metadata = get_pkg_metadata(path);
     let lib_rs = path.join(PATH_SRC_DIR).join("lib.rs");
@@ -274,6 +294,7 @@ fn update(path: &Path) {
         &path.join(PATH_R_IMPL),
         &generate_r_impl_file(&merged, &pkg_metadata.package_name_for_r()),
     );
+    tweak_r_buildignore(path);
 }
 
 fn init(path: &Path, skip_update: bool) {


### PR DESCRIPTION
* Fix `savvy-cli test`
* `savvy-cli update` now updates `.Rbuildignore`
* Use OS's cache dir for `savvy-cli test` instead of `.savvy` directory (close #184)