### PR TITLE
Always public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
   it's `savvy_{original}_ffi`. This change shouldn't affect ordinary users.
   
   This change was necessary to let `#[savvy]` preserve the original function so
-  that we can write unit tests on the function easily. For more details, please
-  read the [Testing section](https://yutannihilation.github.io/savvy/guide/test.html) in the guide.
+  that we can write unit tests on the function easily. One modification is that
+  the function is made public. For more details, please read the [Testing section](https://yutannihilation.github.io/savvy/guide/test.html)
+  in the guide.
 
 * The generated R wrapper file is now named as `000-wrappers.R` instead of
   `wrappers.R`. This makes the file is loaded first so that you can override

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -61,7 +61,7 @@ fn is_built_with_debug() -> savvy::Result<savvy::Sexp> {
 /// @returns A character vector with upper case version of the input.
 /// @export
 #[savvy]
-pub fn to_upper(x: StringSexp) -> savvy::Result<savvy::Sexp> {
+fn to_upper(x: StringSexp) -> savvy::Result<savvy::Sexp> {
     let mut out = OwnedStringSexp::new(x.len())?;
 
     for (i, e) in x.iter().enumerate() {
@@ -84,7 +84,7 @@ pub fn to_upper(x: StringSexp) -> savvy::Result<savvy::Sexp> {
 /// @returns A character vector with upper case version of the input.
 /// @export
 #[savvy]
-pub fn add_suffix(x: StringSexp, y: &str) -> savvy::Result<savvy::Sexp> {
+fn add_suffix(x: StringSexp, y: &str) -> savvy::Result<savvy::Sexp> {
     let mut out = OwnedStringSexp::new(x.len())?;
 
     for (i, e) in x.iter().enumerate() {

--- a/book/src/test.md
+++ b/book/src/test.md
@@ -41,10 +41,9 @@ crate-type = ["staticlib", "lib"]
                            ^^^^^
 ```
 
-Second, if you want to test a function or a struct, it must be public. This is
-because `savvy-cli test` has to build the crate in the `dev` profile or the
-`release` profile, not the test profile, in order to link with the R package.
-So, the visibility is kept as it is unlike `cargo test`.
+Second, if you want to test a function or a struct, it must be public. For the
+ones marked with `#[savvy]` are automatically made public, but, if you want to
+test other functions, you need to add `pub` to it by yourself.
 
 ```rs
 pub fn foo() -> savvy::Result<()> {


### PR DESCRIPTION
Make all function, struct, impl-items, and enum marked with `#[savvy]` public. This is for testing purposes.

Close #198