### PR TITLE
Use #[cfg(savvy_test)] instead of #[cfg(test)] for marking tests for savvy-cli test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ### Breaking changes
 
+* `savvy-cli test` now parses test modules marked with `#[cfg(savvy_test)]`
+  instead of `#[cfg(test)]`. The purpose of this change is to let `cargo test`
+  run for the tests unrelated to a real R sessions.
+
 * Savvy now generates different names of Rust functions and C functions;
   previously, the original function name is used for the FFI functions, but now
   it's `savvy_{original}_ffi`. This change shouldn't affect ordinary users.

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -424,7 +424,7 @@ fn set_name_external(x: &mut Person, name: &str) -> savvy::Result<()> {
     x.set_name(name)
 }
 
-#[cfg(test)]
+#[cfg(savvy_test)]
 mod tests {
     #[test]
     fn test_to_upper() -> savvy::Result<()> {

--- a/book/src/test.md
+++ b/book/src/test.md
@@ -52,9 +52,9 @@ pub fn foo() -> savvy::Result<()> {
 
 ### Test module
 
-You can write tests under a module marked with `#[cfg(savvy_test)]`. A `#[test]`
-function needs to have the return value of `savvy::Result<()>`, which is the
-same convention as `#[savvy]`.
+You can write tests under a module marked with `#[cfg(savvy_test)]` instead of
+`#[cfg(test)]`. A `#[test]` function needs to have the return value of
+`savvy::Result<()>`, which is the same convention as `#[savvy]`.
 
 ```rust
 #[cfg(savvy_test)]

--- a/book/src/test.md
+++ b/book/src/test.md
@@ -121,3 +121,50 @@ For dependencies, `savvy-cli test` picks all dependencies in `[dependencies]`
 and `[dev-dependencies]`. If you need some additional crate for the test code,
 you can just use `[dev-dependencies]` section of the `Cargo.toml` just as you do
 when you do `cargo test`.
+
+
+### Reminder: You can use `cargo test`
+
+While `#[savvy]` requires a real session, you can utilize `cargo test` by
+separating the actual logic to a function that doesn't rely on savvy. For
+example, suppose you have the following function `times_two_int()` that doubles
+the input numbers.
+
+```rust
+#[savvy]
+fn times_two_int(x: IntegerSexp) -> savvy::Result<savvy::Sexp> {
+    let mut out = OwnedIntegerSexp::new(x.len())?;
+
+    for (i, e) in x.iter().enumerate() {
+        if e.is_na() {
+            out.set_na(i)?;
+        } else {
+            out[i] = e * 2;
+        }
+    }
+
+    out.into()
+}
+```
+
+In this case, you can rewrite the code to the following so that you can test
+`times_two_int_impl()` with `cargo test`.
+
+```rust
+#[savvy]
+fn times_two_int(x: IntegerSexp) -> savvy::Result<savvy::Sexp> {
+    let result: Vec<i32> = times_two_int_impl(x.as_slice());
+    result.try_into()
+}
+
+fn times_two_int_impl(x: &[i32]) -> Vec<i32> {
+    x.iter()
+        .map(|x| if x.is_na() { *x } else { *x * 2 })
+        .collect::<Vec<i32>>()
+}
+```
+
+But, as you might notice, this implementation is a bit inefficient that it
+allocates a `Vec<i32>` just to store the temporary result. Like this, separating
+a function might be a bit tricky and it might not be really worth in some cases.
+(In this case, probably the function can return an iterator).

--- a/book/src/test.md
+++ b/book/src/test.md
@@ -52,12 +52,12 @@ pub fn foo() -> savvy::Result<()> {
 
 ### Test module
 
-You can write tests under a module marked with `#[cfg(test)]`. A `#[test]`
+You can write tests under a module marked with `#[cfg(savvy_test)]`. A `#[test]`
 function needs to have the return value of `savvy::Result<()>`, which is the
 same convention as `#[savvy]`.
 
 ```rust
-#[cfg(test)]
+#[cfg(savvy_test)]
 mod test {
     use savvy::OwnedIntegerSexp;
 
@@ -82,7 +82,7 @@ pub fn your_fn(x: IntegerSexp) -> savvy::Result<()> {
     // ...snip...
 }
 
-#[cfg(test)]
+#[cfg(savvy_test)]
 mod test {
     use savvy::OwnedIntegerSexp;
 

--- a/savvy-bindgen/src/parse_file.rs
+++ b/savvy-bindgen/src/parse_file.rs
@@ -158,7 +158,7 @@ impl ParsedResult {
                 let is_test_mod = item_mod
                     .attrs
                     .iter()
-                    .any(|attr| attr == &parse_quote!(#[cfg(test)]));
+                    .any(|attr| attr == &parse_quote!(#[cfg(savvy_test)]));
 
                 match (&item_mod.content, is_test_mod) {
                     (None, false) => {
@@ -335,10 +335,10 @@ fn transform_test_mod(
 ) -> ParsedTestCase {
     let mut item_mod = item_mod.clone();
 
-    // Remove #[cfg(test)]
+    // Remove #[cfg(savvy_test)]
     item_mod
         .attrs
-        .retain(|attr| attr != &parse_quote!(#[cfg(test)]));
+        .retain(|attr| attr != &parse_quote!(#[cfg(savvy_test)]));
 
     item_mod.ident = format_ident!("__UNIQUE_PREFIX__mod_{}", item_mod.ident);
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -130,7 +130,7 @@ pub fn assert_eq_r_code<T1: Into<Sexp>, T2: AsRef<str>>(actual: T1, expected: T2
     assert!(is_r_identical(actual, parsed));
 }
 
-#[cfg(test)]
+#[cfg(savvy_test)]
 mod test {
     use crate::{IntegerSexp, RealSexp};
 

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -452,7 +452,7 @@ impl IndexMut<usize> for OwnedIntegerSexp {
     }
 }
 
-#[cfg(test)]
+#[cfg(savvy_test)]
 mod test {
     use super::OwnedIntegerSexp;
     use crate::NotAvailableValue;


### PR DESCRIPTION
There can be two types of tests modules

* tests that need to be run by `savvy-cli test` (for a real R session)
* tests that need to be run by `cargo test` (for the usual testing behaviors like visibility)

so this needs a separate marker.