### PR TITLE
Use Drop mechanism for managing PROTECT and UNPROTECT

### DIFF
--- a/book/src/struct.md
+++ b/book/src/struct.md
@@ -282,7 +282,7 @@ doesn't work well, you can use `T`.
 
 Under the hood, the `Person` struct is stored in `EXTPTRSXP`. But, you don't
 need to care about how to deal with `EXTPTRSXP`. This is because it's stored in
-a closure environemnt on creation and never exposed to the user. As it's
+a closure environment on creation and never exposed to the user. As it's
 guaranteed on R's side that `self` is always a `EXTPTRSXP` of `Person`, Rust
 code just restore a `Person` instance from the `EXTPTRSXP` without any checks.
 

--- a/src/protect.rs
+++ b/src/protect.rs
@@ -37,6 +37,28 @@ use savvy_ffi::{
     SET_TAG, SEXP,
 };
 
+// Protection by `Rf_protect()`. This struct is needed for auto-unprotect when
+// returning from the scope.
+
+pub(crate) struct LocalProtection {}
+
+impl Drop for LocalProtection {
+    fn drop(&mut self) {
+        unsafe { Rf_unprotect(1) };
+    }
+}
+
+/// Provide a protection that lasts within the function scope, i.e.,
+/// automatically cleans up by `Rf_unprotect()`. This might not be very
+/// efficient as this can execute `Rf_unprotect(1)` multiple times where it
+/// could be `Rf_unprotect(n)` once. But, I found manual `Rf_unprotect()` is
+/// almost impossible for human considering there are many early return by `?`,
+/// so this should be better than failure.
+pub(crate) fn local_protect(obj: SEXP) -> LocalProtection {
+    unsafe { Rf_protect(obj) };
+    LocalProtection {}
+}
+
 pub(crate) struct PreservedList(SEXP);
 
 // cf. https://doc.rust-lang.org/stable/nomicon/send-and-sync.html
@@ -57,10 +79,12 @@ pub fn insert_to_preserved_list(obj: SEXP) -> SEXP {
         }
 
         // Protect the object until the operation finishes
-        Rf_protect(obj);
+        local_protect(obj);
 
         let preserved = PRESERVED_LIST.0;
-        let token = Rf_protect(Rf_cons(preserved, CDR(preserved)));
+        let token = Rf_cons(preserved, CDR(preserved));
+
+        local_protect(token);
 
         SET_TAG(token, obj);
         SETCDR(preserved, token);
@@ -68,8 +92,6 @@ pub fn insert_to_preserved_list(obj: SEXP) -> SEXP {
         if CDR(token) != R_NilValue {
             SETCAR(CDR(token), token);
         }
-
-        Rf_unprotect(2);
 
         token
     }

--- a/src/protect.rs
+++ b/src/protect.rs
@@ -37,8 +37,8 @@ use savvy_ffi::{
     SET_TAG, SEXP,
 };
 
-// Protection by `Rf_protect()`. This struct is needed for auto-unprotect when
-// returning from the scope.
+// Protection mechanism by `Rf_protect()`. This struct is needed for
+// auto-unprotect when returning from the scope.
 
 pub(crate) struct LocalProtection {}
 
@@ -58,6 +58,9 @@ pub(crate) fn local_protect(obj: SEXP) -> LocalProtection {
     unsafe { Rf_protect(obj) };
     LocalProtection {}
 }
+
+// Protection mechanism by a doubly-linked pairlist.
+// cf. https://cpp11.r-lib.org/articles/internals.html#protection
 
 pub(crate) struct PreservedList(SEXP);
 

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -259,8 +259,7 @@ impl OwnedStringSexp {
             // CHARSXP. So, the `CHARSXP` needs to be protected.
             let charsxp = str_to_charsxp(value.as_ref())?;
             local_protect(charsxp);
-            let out = crate::unwind_protect(|| savvy_ffi::Rf_ScalarString(charsxp))?;
-            out
+            crate::unwind_protect(|| savvy_ffi::Rf_ScalarString(charsxp))?
         };
         Self::new_from_raw_sexp(sexp, 1)
     }

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -5,7 +5,7 @@ use savvy_ffi::{R_NaString, Rf_xlength, R_CHAR, SET_STRING_ELT, SEXP, STRING_ELT
 use super::na::NotAvailableValue;
 use super::utils::{assert_len, str_to_charsxp};
 use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
-use crate::protect;
+use crate::protect::{self, local_protect};
 
 /// An external SEXP of a character vector.
 pub struct StringSexp(pub SEXP);
@@ -258,9 +258,8 @@ impl OwnedStringSexp {
             // Note: unlike `new()`, this allocates a STRSXP after creating a
             // CHARSXP. So, the `CHARSXP` needs to be protected.
             let charsxp = str_to_charsxp(value.as_ref())?;
-            savvy_ffi::Rf_protect(charsxp);
+            local_protect(charsxp);
             let out = crate::unwind_protect(|| savvy_ffi::Rf_ScalarString(charsxp))?;
-            savvy_ffi::Rf_unprotect(1);
             out
         };
         Self::new_from_raw_sexp(sexp, 1)


### PR DESCRIPTION
Provide a protection that lasts within the function scope, i.e.,
automatically cleans up by `Rf_unprotect()`. This might not be very
efficient as this can execute `Rf_unprotect(1)` multiple times where it
could be `Rf_unprotect(n)` once. But, I found manual `Rf_unprotect()` is
almost impossible for human considering there are many early return by `?`,
so this should be better than failure.