### PR TITLE
Do not use `SETLENGTH`

### DIFF
--- a/.github/workflows/check-non-api.yaml
+++ b/.github/workflows/check-non-api.yaml
@@ -36,4 +36,6 @@ jobs:
           if [ -n "${NON_API}" ]; then
             echo 'Found what they call "non-API"!'
             exit 1
+          else
+            echo "OK!"
           fi

--- a/.github/workflows/check-non-api.yaml
+++ b/.github/workflows/check-non-api.yaml
@@ -26,7 +26,7 @@ jobs:
 
           REGEX=$(Rscript tmp.R)
           
-          NON_API=$(grep -R -E "${REGEX}" ./savvy-ffi/src/)
+          NON_API=$(grep -R -E "${REGEX}" ./savvy-ffi/src/ || true)
 
           echo "Check result:"
           echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### Minor improvements
+
+* Now savvy no longer uses `SETLENGTH`, which is a so-called "non-API" thing.
+
 ## [v0.6.0] (2024-04-20)
 
 ### Breaking changes

--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -69,7 +69,7 @@ extern "C" {
 // Allocation and attributes
 extern "C" {
     pub fn Rf_xlength(arg1: SEXP) -> R_xlen_t;
-    pub fn Rf_xlengthgets(x: SEXP, v: R_xlen_t);
+    pub fn Rf_xlengthgets(arg1: SEXP, arg2: R_xlen_t);
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_getAttrib(arg1: SEXP, arg2: SEXP) -> SEXP;

--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -69,7 +69,7 @@ extern "C" {
 // Allocation and attributes
 extern "C" {
     pub fn Rf_xlength(arg1: SEXP) -> R_xlen_t;
-    pub fn SETLENGTH(x: SEXP, v: R_xlen_t);
+    pub fn Rf_xlengthgets(x: SEXP, v: R_xlen_t);
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_getAttrib(arg1: SEXP, arg2: SEXP) -> SEXP;

--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -69,7 +69,7 @@ extern "C" {
 // Allocation and attributes
 extern "C" {
     pub fn Rf_xlength(arg1: SEXP) -> R_xlen_t;
-    pub fn Rf_xlengthgets(arg1: SEXP, arg2: R_xlen_t);
+    pub fn Rf_xlengthgets(arg1: SEXP, arg2: R_xlen_t) -> SEXP;
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_getAttrib(arg1: SEXP, arg2: SEXP) -> SEXP;

--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -69,7 +69,6 @@ extern "C" {
 // Allocation and attributes
 extern "C" {
     pub fn Rf_xlength(arg1: SEXP) -> R_xlen_t;
-    pub fn Rf_xlengthgets(arg1: SEXP, arg2: R_xlen_t) -> SEXP;
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_getAttrib(arg1: SEXP, arg2: SEXP) -> SEXP;

--- a/src/sexp/complex.rs
+++ b/src/sexp/complex.rs
@@ -214,10 +214,14 @@ impl OwnedComplexSexp {
 
                 let new_len = last_index + 1;
                 if new_len == upper {
+                    // If the length is the same as expected, use it as it is.
                     Self::new_from_raw_sexp(inner, upper)
                 } else {
+                    // If the length is shorter than expected, re-allocate a new
+                    // SEXP and copy the values into it.
                     let mut out = unsafe { Self::new_without_init(new_len)? };
-                    let raw_slice = unsafe { std::slice::from_raw_parts(raw, new_len) }; // ignore the part over
+                    // `raw` is longer than new_len, but the elements over new_len are ignored
+                    let raw_slice = unsafe { std::slice::from_raw_parts(raw, new_len) };
                     out.as_mut_slice().copy_from_slice(raw_slice);
 
                     Ok(out)

--- a/src/sexp/complex.rs
+++ b/src/sexp/complex.rs
@@ -213,7 +213,7 @@ impl OwnedComplexSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
+                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/complex.rs
+++ b/src/sexp/complex.rs
@@ -213,7 +213,7 @@ impl OwnedComplexSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
+                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -300,11 +300,15 @@ impl OwnedIntegerSexp {
 
                 let new_len = last_index + 1;
                 if new_len == upper {
+                    // If the length is the same as expected, use it as it is.
                     Self::new_from_raw_sexp(inner, upper)
                 } else {
+                    // If the length is shorter than expected, re-allocate a new
+                    // SEXP and copy the values into it.
                     let out = unsafe { Self::new_without_init(new_len)? };
                     let dst = unsafe { std::slice::from_raw_parts_mut(out.raw, new_len) };
-                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) }; // ignore the part over
+                    // `raw` is longer than new_len, but the elements over new_len are ignored
+                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) };
                     dst.copy_from_slice(src);
 
                     Ok(out)

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -299,7 +299,7 @@ impl OwnedIntegerSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
+                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -299,7 +299,7 @@ impl OwnedIntegerSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
+                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -4,7 +4,7 @@ use savvy_ffi::{INTEGER, INTSXP, SEXP};
 
 use super::utils::assert_len;
 use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
-use crate::protect;
+use crate::protect::{self, local_protect};
 use crate::NotAvailableValue; // for na()
 
 /// An external SEXP of an integer vector.
@@ -284,27 +284,31 @@ impl OwnedIntegerSexp {
                 // (e.g. `(0..10).filter(|x| x % 2 == 0)`), so it needs to be
                 // truncated to the actual length at last.
 
-                let mut out = unsafe { Self::new_without_init(upper)? };
+                let inner = crate::alloc_vector(INTSXP, upper as _)?;
+                local_protect(inner);
+                let raw = unsafe { INTEGER(inner) };
 
                 let mut last_index = 0;
                 for (i, v) in iter.enumerate() {
                     // The upper bound of size_hint() is just for optimization
-                    // and what we should not trust. So, we should't use
-                    // `set_elt_unchecked()` here.
-                    out.set_elt(i, v)?;
+                    // and what we should not trust.
+                    assert_len(upper, i)?;
+                    unsafe { *(raw.add(i)) = v };
 
                     last_index = i;
                 }
 
                 let new_len = last_index + 1;
-                if new_len != upper {
-                    unsafe {
-                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
-                    }
-                    out.len = new_len;
-                }
+                if new_len == upper {
+                    Self::new_from_raw_sexp(inner, upper)
+                } else {
+                    let out = unsafe { Self::new_without_init(new_len)? };
+                    let dst = unsafe { std::slice::from_raw_parts_mut(out.raw, new_len) };
+                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) }; // ignore the part over
+                    dst.copy_from_slice(src);
 
-                Ok(out)
+                    Ok(out)
+                }
             }
             (_, None) => {
                 // When the length is not known at all, collect() it first.

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -273,7 +273,7 @@ impl OwnedLogicalSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
+                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -273,7 +273,7 @@ impl OwnedLogicalSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
+                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -274,11 +274,15 @@ impl OwnedLogicalSexp {
 
                 let new_len = last_index + 1;
                 if new_len == upper {
+                    // If the length is the same as expected, use it as it is.
                     Self::new_from_raw_sexp(inner, upper)
                 } else {
+                    // If the length is shorter than expected, re-allocate a new
+                    // SEXP and copy the values into it.
                     let out = unsafe { Self::new_without_init(new_len)? };
                     let dst = unsafe { std::slice::from_raw_parts_mut(out.raw, new_len) };
-                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) }; // ignore the part over
+                    // `raw` is longer than new_len, but the elements over new_len are ignored
+                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) };
                     dst.copy_from_slice(src);
 
                     Ok(out)

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -1,7 +1,7 @@
 use savvy_ffi::{R_NaInt, LGLSXP, LOGICAL, SET_LOGICAL_ELT, SEXP};
 
-use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
-use crate::protect;
+use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, utils::assert_len, Sexp};
+use crate::protect::{self, local_protect};
 
 /// An external SEXP of a logical vector.
 pub struct LogicalSexp(pub SEXP);
@@ -258,27 +258,31 @@ impl OwnedLogicalSexp {
                 // (e.g. `(0..10).filter(|x| x % 2 == 0)`), so it needs to be
                 // truncated to the actual length at last.
 
-                let mut out = unsafe { Self::new_without_init(upper)? };
+                let inner = crate::alloc_vector(LGLSXP, upper as _)?;
+                local_protect(inner);
+                let raw = unsafe { LOGICAL(inner) };
 
                 let mut last_index = 0;
                 for (i, v) in iter.enumerate() {
                     // The upper bound of size_hint() is just for optimization
-                    // and what we should not trust. So, we should't use
-                    // `set_elt_unchecked()` here.
-                    out.set_elt(i, v)?;
+                    // and what we should not trust.
+                    assert_len(upper, i)?;
+                    unsafe { *(raw.add(i)) = v as _ };
 
                     last_index = i;
                 }
 
                 let new_len = last_index + 1;
-                if new_len != upper {
-                    unsafe {
-                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
-                    }
-                    out.len = new_len;
-                }
+                if new_len == upper {
+                    Self::new_from_raw_sexp(inner, upper)
+                } else {
+                    let out = unsafe { Self::new_without_init(new_len)? };
+                    let dst = unsafe { std::slice::from_raw_parts_mut(out.raw, new_len) };
+                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) }; // ignore the part over
+                    dst.copy_from_slice(src);
 
-                Ok(out)
+                    Ok(out)
+                }
             }
             (_, None) => {
                 // When the length is not known at all, collect() it first.

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -303,11 +303,15 @@ impl OwnedRealSexp {
 
                 let new_len = last_index + 1;
                 if new_len == upper {
+                    // If the length is the same as expected, use it as it is.
                     Self::new_from_raw_sexp(inner, upper)
                 } else {
+                    // If the length is shorter than expected, re-allocate a new
+                    // SEXP and copy the values into it.
                     let out = unsafe { Self::new_without_init(new_len)? };
                     let dst = unsafe { std::slice::from_raw_parts_mut(out.raw, new_len) };
-                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) }; // ignore the part over
+                    // `raw` is longer than new_len, but the elements over new_len are ignored
+                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) };
                     dst.copy_from_slice(src);
 
                     Ok(out)

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -302,7 +302,7 @@ impl OwnedRealSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
+                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -302,7 +302,7 @@ impl OwnedRealSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
+                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -4,7 +4,7 @@ use savvy_ffi::{REAL, REALSXP, SEXP};
 
 use super::utils::assert_len;
 use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
-use crate::protect;
+use crate::protect::{self, local_protect};
 use crate::NotAvailableValue; // for na()
 
 /// An external SEXP of a real vector.
@@ -287,27 +287,31 @@ impl OwnedRealSexp {
                 // (e.g. `(0..10).filter(|x| x % 2 == 0)`), so it needs to be
                 // truncated to the actual length at last.
 
-                let mut out = unsafe { Self::new_without_init(upper)? };
+                let inner = crate::alloc_vector(REALSXP, upper as _)?;
+                local_protect(inner);
+                let raw = unsafe { REAL(inner) };
 
                 let mut last_index = 0;
                 for (i, v) in iter.enumerate() {
                     // The upper bound of size_hint() is just for optimization
-                    // and what we should not trust. So, we should't use
-                    // `set_elt_unchecked()` here.
-                    out.set_elt(i, v)?;
+                    // and what we should not trust.
+                    assert_len(upper, i)?;
+                    unsafe { *(raw.add(i)) = v };
 
                     last_index = i;
                 }
 
                 let new_len = last_index + 1;
-                if new_len != upper {
-                    unsafe {
-                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
-                    }
-                    out.len = new_len;
-                }
+                if new_len == upper {
+                    Self::new_from_raw_sexp(inner, upper)
+                } else {
+                    let out = unsafe { Self::new_without_init(new_len)? };
+                    let dst = unsafe { std::slice::from_raw_parts_mut(out.raw, new_len) };
+                    let src = unsafe { std::slice::from_raw_parts(raw, new_len) }; // ignore the part over
+                    dst.copy_from_slice(src);
 
-                Ok(out)
+                    Ok(out)
+                }
             }
             (_, None) => {
                 // When the length is not known at all, collect() it first.

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -203,7 +203,7 @@ impl OwnedStringSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::SETLENGTH(out.inner, new_len as _);
+                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -187,28 +187,29 @@ impl OwnedStringSexp {
                 // (e.g. `(0..10).filter(|x| x % 2 == 0)`), so it needs to be
                 // truncated to the actual length at last.
 
-                // string doesn't have new_without_init() method
-                let mut out = Self::new(upper)?;
+                let inner = crate::alloc_vector(STRSXP, upper as _)?;
+                local_protect(inner);
 
                 let mut last_index = 0;
                 for (i, v) in iter.enumerate() {
                     // The upper bound of size_hint() is just for optimization
-                    // and what we should not trust. So, we should't use
-                    // `set_elt_unchecked()` here.
-                    out.set_elt(i, v.as_ref())?;
+                    // and what we should not trust.
+                    assert_len(upper, i)?;
+                    unsafe { SET_STRING_ELT(inner, i as _, str_to_charsxp(v.as_ref())?) };
 
                     last_index = i;
                 }
 
                 let new_len = last_index + 1;
-                if new_len != upper {
-                    unsafe {
-                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
+                if new_len == upper {
+                    Self::new_from_raw_sexp(inner, upper)
+                } else {
+                    let mut out = Self::new(new_len)?;
+                    for i in 0..new_len {
+                        unsafe { out.set_elt_unchecked(i, STRING_ELT(inner, i as _)) };
                     }
-                    out.len = new_len;
+                    Ok(out)
                 }
-
-                Ok(out)
             }
             (_, None) => {
                 // When the length is not known at all, collect() it first.

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -203,7 +203,7 @@ impl OwnedStringSexp {
                 let new_len = last_index + 1;
                 if new_len != upper {
                     unsafe {
-                        savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
+                        out.inner = savvy_ffi::Rf_xlengthgets(out.inner, new_len as _);
                     }
                     out.len = new_len;
                 }

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -202,8 +202,11 @@ impl OwnedStringSexp {
 
                 let new_len = last_index + 1;
                 if new_len == upper {
+                    // If the length is the same as expected, use it as it is.
                     Self::new_from_raw_sexp(inner, upper)
                 } else {
+                    // If the length is shorter than expected, re-allocate a new
+                    // SEXP and copy the values into it.
                     let mut out = Self::new(new_len)?;
                     for i in 0..new_len {
                         unsafe { out.set_elt_unchecked(i, STRING_ELT(inner, i as _)) };

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -84,7 +84,6 @@ fn show() -> Result<(), DynError> {
         .allowlist_function("R_IsNA")
         // Allocation and attributes
         .allowlist_function("Rf_xlength")
-        .allowlist_function("Rf_xlengthgets")
         .allowlist_function("Rf_allocVector")
         .allowlist_function("Rf_install")
         .allowlist_function("Rf_getAttrib")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -84,7 +84,7 @@ fn show() -> Result<(), DynError> {
         .allowlist_function("R_IsNA")
         // Allocation and attributes
         .allowlist_function("Rf_xlength")
-        .allowlist_function("SETLENGTH")
+        .allowlist_function("Rf_xlengthgets")
         .allowlist_function("Rf_allocVector")
         .allowlist_function("Rf_install")
         .allowlist_function("Rf_getAttrib")


### PR DESCRIPTION
Close #209.

cf. https://fosstodon.org/@shikokuchuo/112325582047868252

But, the implementation is not efficient. Probably manual `Rf_allocVector()` + memcpy should faster. Or, maybe I can just `collect()` into a `Vec` first?

https://github.com/r-devel/r-svn/blob/faa2ca57cc03c26c49a5de39db980268c6c4cc67/src/main/builtin.c#L832C6-L832C17

Anyway, let's think about it later. I'd like to get rid of the CI error for now.