### PR TITLE
Support initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### New features
+
+* If `#[savvy]` is placed on a function whose argument is a `*mut DllInfo`, the
+  function is called when the package is loaded. See [the guide](https://yutannihilation.github.io/savvy/guide/initialization_routine.html) for more details.
+
 ## [v0.6.1] (2024-04-26)
 
 ### Minor improvements

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -119,6 +119,11 @@ SEXP savvy_set_name_external__impl(SEXP x, SEXP name) {
     return handle_result(res);
 }
 
+SEXP savvy_init_foo__impl(DllInfo* _dll_info) {
+    SEXP res = savvy_init_foo__ffi(_dll_info);
+    return handle_result(res);
+}
+
 SEXP savvy_get_class_int__impl(SEXP x) {
     SEXP res = savvy_get_class_int__ffi(x);
     return handle_result(res);
@@ -580,6 +585,9 @@ static const R_CallMethodDef CallEntries[] = {
 };
 
 void R_init_savvyExamples(DllInfo *dll) {
-  R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
-  R_useDynamicSymbols(dll, FALSE);
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+
+    // Functions for initialzation, if any.
+    savvy_init_foo__impl(dll);
 }

--- a/R-package/src/rust/api.h
+++ b/R-package/src/rust/api.h
@@ -15,6 +15,7 @@ SEXP savvy_list_with_names_and_values__ffi(void);
 SEXP savvy_external_person_new__ffi(void);
 SEXP savvy_get_name_external__ffi(SEXP x);
 SEXP savvy_set_name_external__ffi(SEXP x, SEXP name);
+SEXP savvy_init_foo__ffi(DllInfo* _dll_info);
 SEXP savvy_get_class_int__ffi(SEXP x);
 SEXP savvy_get_names_int__ffi(SEXP x);
 SEXP savvy_get_dim_int__ffi(SEXP x);

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -21,7 +21,7 @@ mod mod1;
 // This should not be parsed
 // mod mod2;
 
-use savvy::{r_print, savvy, OwnedListSexp};
+use savvy::{r_eprintln, r_print, savvy, OwnedListSexp};
 
 use savvy::{
     IntegerSexp, ListSexp, LogicalSexp, OwnedIntegerSexp, OwnedLogicalSexp, OwnedRealSexp,
@@ -421,4 +421,10 @@ mod tests {
         savvy::assert_eq_r_code(result, r#"c("foo_suf", "bar_suf")"#);
         Ok(())
     }
+}
+
+#[savvy]
+fn init_foo(_dll_info: *mut savvy::ffi::DllInfo) -> savvy::Result<()> {
+    r_eprintln!("Initialized!");
+    Ok(())
 }

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -26,4 +26,5 @@
 - [Calling R Function]()
 - [Testing](./test.md)
 - [Advanced Topics](./advanced_topics.md)
+    - [Initialization Routine](./initialization_routine.md)
 - [Comparison with extendr](./extendr.md)

--- a/book/src/initialization_routine.md
+++ b/book/src/initialization_routine.md
@@ -1,0 +1,58 @@
+# Initialization Routine
+
+A special convention of `#[savvy]` is that, if `#[savvy]` is placed on a
+function that takes `*mut DllInfo` as its argument, the function is called when
+the package is loaded, which is what [Writing R Extension][wre] calls
+"initialization routine".
+
+[wre]: https://cran.r-project.org/doc/manuals/r-release/R-exts.html#dyn_002eload-and-dyn_002eunload
+
+For example, if you write such a Rust function like this,
+
+``` rust
+#[savvy]
+fn init_foo(_dll_info: *mut savvy::ffi::DllInfo) -> savvy::Result<()> {
+    r_eprintln!("Initialized!");
+    Ok(())
+}
+```
+
+You'll see the following message on your R session when you load the package.
+
+```r
+library(yourPackage)
+#> Initialized!
+```
+
+Under the hood, `savvy-cli update .` inserts the following line in a C function
+`R_init_*()`, which is called when the DLL is loaded.
+
+``` c
+void R_init_yourPackage(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+
+    savvy_init_foo__impl(dll); // added!
+}
+```
+
+This is useful for initializing resources. For example, you can initialize a
+global variable.
+
+``` rust
+use std::sync::OnceLock;
+
+static GLOBAL_FOO: OnceLock<Foo> = OnceLock::new();
+
+#[savvy]
+fn init_global_foo(dll_info: *mut savvy::ffi::DllInfo) -> savvy::Result<()> {
+    let foo = Foo::new();
+    GLOBAL_FOO.set(foo);
+
+    Ok(())
+}
+```
+
+You can also register an ALTREP class using this mechanism.
+
+(TBD)

--- a/savvy-bindgen/src/gen/r.rs
+++ b/savvy-bindgen/src/gen/r.rs
@@ -117,7 +117,7 @@ fn generate_r_impl_for_impl(
         match savvy_fn.fn_type {
             SavvyFnType::AssociatedFunction(_) => associated_fns.push(savvy_fn),
             SavvyFnType::Method { .. } => method_fns.push(savvy_fn),
-            SavvyFnType::BareFunction => panic!("Something is wrong"),
+            _ => panic!("Something is wrong"),
         }
     }
 
@@ -298,6 +298,8 @@ pub fn generate_r_impl_file(result: &MergedResult, pkg_name: &str) -> String {
     let r_fns = result
         .bare_fns
         .iter()
+        // initializaion functions don't need the R interface
+        .filter(|x| !matches!(x.fn_type, SavvyFnType::InitFunction))
         .map(|x| x.to_r_function())
         .collect::<Vec<String>>()
         .join("\n");

--- a/savvy-bindgen/src/gen/rust.rs
+++ b/savvy-bindgen/src/gen/rust.rs
@@ -22,7 +22,7 @@ impl SavvyFn {
 
         let mut out: syn::ItemFn = match &self.fn_type {
             // A bare function
-            SavvyFnType::BareFunction => parse_quote!(
+            SavvyFnType::BareFunction | SavvyFnType::InitFunction => parse_quote!(
                 #(#attrs)*
                 unsafe fn #fn_name_inner( #(#args_pat: #args_ty),* ) #ret_ty {
                     #(#stmts_additional)*

--- a/savvy-bindgen/src/lib.rs
+++ b/savvy-bindgen/src/lib.rs
@@ -13,6 +13,7 @@ pub use ir::savvy_enum::SavvyEnum;
 pub use ir::savvy_fn::{SavvyFn, SavvyFnArg, SavvyFnType};
 pub use ir::savvy_impl::SavvyImpl;
 pub use ir::savvy_struct::SavvyStruct;
+
 pub use ir::{merge_parsed_results, MergedResult, ParsedResult};
 
 pub use utils::extract_docs;

--- a/savvy-bindgen/src/parse_file.rs
+++ b/savvy-bindgen/src/parse_file.rs
@@ -8,7 +8,7 @@ use crate::{
     extract_docs, ir::ParsedTestCase, ParsedResult, SavvyEnum, SavvyFn, SavvyImpl, SavvyStruct,
 };
 
-fn is_marked(attrs: &[syn::Attribute]) -> bool {
+fn is_savvified(attrs: &[syn::Attribute]) -> bool {
     attrs.iter().any(|attr| attr == &parse_quote!(#[savvy]))
 }
 
@@ -86,7 +86,7 @@ impl ParsedResult {
     fn parse_item(&mut self, item: &syn::Item, location: &str) {
         match item {
             syn::Item::Fn(item_fn) => {
-                if is_marked(item_fn.attrs.as_slice()) {
+                if is_savvified(item_fn.attrs.as_slice()) {
                     self.bare_fns
                         .push(SavvyFn::from_fn(item_fn).expect("Failed to parse function"))
                 }
@@ -101,7 +101,7 @@ impl ParsedResult {
             }
 
             syn::Item::Impl(item_impl) => {
-                if is_marked(item_impl.attrs.as_slice()) {
+                if is_savvified(item_impl.attrs.as_slice()) {
                     self.impls
                         .push(SavvyImpl::new(item_impl).expect("Failed to parse impl"))
                 }
@@ -125,7 +125,7 @@ impl ParsedResult {
             }
 
             syn::Item::Struct(item_struct) => {
-                if is_marked(item_struct.attrs.as_slice()) {
+                if is_savvified(item_struct.attrs.as_slice()) {
                     self.structs
                         .push(SavvyStruct::new(item_struct).expect("Failed to parse struct"))
                 }
@@ -140,7 +140,7 @@ impl ParsedResult {
             }
 
             syn::Item::Enum(item_enum) => {
-                if is_marked(item_enum.attrs.as_slice()) {
+                if is_savvified(item_enum.attrs.as_slice()) {
                     self.enums
                         .push(SavvyEnum::new(item_enum).expect("Failed to parse enum"))
                 }

--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -159,7 +159,7 @@ extern "C" {
 
 // External pointer
 
-pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
+pub type R_CFinalizer_t = Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
     pub fn R_ExternalPtrAddr(s: SEXP) -> *mut ::std::os::raw::c_void;
@@ -242,3 +242,6 @@ extern "C" {
     pub fn Rprintf(arg1: *const ::std::os::raw::c_char, ...);
     pub fn REprintf(arg1: *const ::std::os::raw::c_char, ...);
 }
+
+// misc
+pub type DllInfo = *mut ::std::os::raw::c_void;

--- a/savvy-macro/src/lib.rs
+++ b/savvy-macro/src/lib.rs
@@ -15,6 +15,7 @@ pub fn savvy(_args: TokenStream, input: TokenStream) -> TokenStream {
     } else if let Ok(mut item_enum) = syn::parse::<syn::ItemEnum>(input.clone()) {
         savvy_enum(&mut item_enum)
     } else {
+        // TODO: how can I convert TokenStream to Span?
         let parse_result = syn::parse::<syn::ItemImpl>(input.clone());
         return proc_macro::TokenStream::from(
             syn::Error::new(

--- a/savvy-macro/tests/cases/simple_cases.rs
+++ b/savvy-macro/tests/cases/simple_cases.rs
@@ -42,4 +42,19 @@ enum Foo {
     B = 100,
 }
 
+#[savvy]
+fn init_wrong_type(x: DllInfo) -> savvy::Result<()> {
+    Ok(())
+}
+
+#[savvy]
+fn init_wrong_type2(x: *const DllInfo) -> savvy::Result<()> {
+    Ok(())
+}
+
+#[savvy]
+fn init_wrong_type3(x: *mut DllInfo, y: i32) -> savvy::Result<()> {
+    Ok(())
+}
+
 fn main() {}

--- a/savvy-macro/tests/cases/simple_cases.stderr
+++ b/savvy-macro/tests/cases/simple_cases.stderr
@@ -47,3 +47,21 @@ error: savvy doesn't support an enum with discreminant
    |
 42 |     B = 100,
    |         ^^^
+
+error: DllInfo must be `*mut DllInfo`
+  --> tests/cases/simple_cases.rs:46:23
+   |
+46 | fn init_wrong_type(x: DllInfo) -> savvy::Result<()> {
+   |                       ^^^^^^^
+
+error: DllInfo must be `*mut DllInfo`
+  --> tests/cases/simple_cases.rs:51:24
+   |
+51 | fn init_wrong_type2(x: *const DllInfo) -> savvy::Result<()> {
+   |                        ^^^^^^^^^^^^^^
+
+error: Initialization function can accept `*mut DllInfo` only
+  --> tests/cases/simple_cases.rs:56:1
+   |
+56 | fn init_wrong_type3(x: *mut DllInfo, y: i32) -> savvy::Result<()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,1 +1,2 @@
+pub use savvy_ffi::DllInfo;
 pub use savvy_ffi::SEXP;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -156,7 +156,8 @@ fn show() -> Result<(), DynError> {
         .allowlist_function("Rf_errorcall")
         // I/O
         .allowlist_function("Rprintf")
-        .allowlist_function("REprintf");
+        .allowlist_function("REprintf")
+        .allowlist_type("DllInfo");
 
     let bindings = builder.generate().expect("Unable to generate bindings");
 


### PR DESCRIPTION
Close #208

If `#[savvy]` is placed on a function that takes `DllInfo` as argument, it's executed in the initialization routine. This is a bit tricky, but, in this way, I don't need to introduce another macro notation like `#[savvy_init]`.

Rust:

``` rust
#[savvy]
fn init_foo(_dll_info: *mut savvy::ffi::DllInfo) -> savvy::Result<()> {
    r_eprintln!("Initialized!");
    Ok(())
}
```

C:

``` c
void R_init_savvyExamples(DllInfo *dll) {
    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
    R_useDynamicSymbols(dll, FALSE);

    savvy_init_foo__impl(dll); // NEW!
}
```

R session:
```r
library(savvyExamples)
#> Initialized!
```