### PR TITLE
Fix minor clippy warnings

### DIFF
--- a/savvy-bindgen/src/ir/mod.rs
+++ b/savvy-bindgen/src/ir/mod.rs
@@ -94,7 +94,7 @@ pub fn merge_parsed_results(results: Vec<ParsedResult>) -> MergedResult {
             let key = e.ty.to_string();
             match impl_map.get_mut(&key) {
                 Some(merged) => {
-                    merged.docs = e.docs.clone();
+                    merged.docs.clone_from(&e.docs);
                 }
                 None => {
                     impl_map.insert(


### PR DESCRIPTION
```
warning: assigning the result of `Clone::clone()` may be inefficient
  --> savvy-bindgen\src\ir\mod.rs:97:21
   |
97 |                     merged.docs = e.docs.clone();
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `merged.docs.clone_from(&e.docs)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
   = note: `#[warn(clippy::assigning_clones)]` on by default

warning: `savvy-bindgen` (lib) generated 1 warning
   Compiling savvy-macro v0.6.1 (C:\Users\Yutani\Documents\GitHub\savvy\savvy-macro)
warning: transmute used without annotations
  --> src\unwind_protect.rs:31:29
   |
31 |         let fun = std::mem::transmute(fun_ptr);
   |                             ^^^^^^^^^ help: consider adding missing annotations: `transmute::<*const (), std::option::Option<unsafe extern "C" fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void>>`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_transmute_annotations
   = note: `#[warn(clippy::missing_transmute_annotations)]` on by default

warning: transmute used without annotations
  --> src\unwind_protect.rs:32:30
   |
32 |         let data = std::mem::transmute(&f as *const F);
   |                              ^^^^^^^^^ help: consider adding missing annotations: `transmute::<*const F, *mut std::ffi::c_void>`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_transmute_annotations
```