### PR TITLE
Logging

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -76,7 +76,7 @@ jobs:
           crate-type = ["staticlib"]
 
           [dependencies]
-          savvy = { path = "../savvy", features = ["complex", "altrep"] }
+          savvy = { path = "../savvy", features = ["complex", "altrep", "logger"] }
           savvy-ffi = { path = "../savvy/savvy-ffi" }
 
           [workspace.package]

--- a/.github/workflows/wasm_and_arm64.yaml
+++ b/.github/workflows/wasm_and_arm64.yaml
@@ -32,7 +32,7 @@ jobs:
           crate-type = ["staticlib"]
 
           [dependencies]
-          savvy = { path = "../savvy", features = ["complex", "altrep"] }
+          savvy = { path = "../savvy", features = ["complex", "altrep", "logger"] }
           savvy-ffi = { path = "../savvy/savvy-ffi" }
 
           [workspace.package]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@
   }
   ```
 
+* Savvy now provides `r_stdout()` and `r_stderr()` to be used with interfaces
+  that require `std::io::Write`. Also, you can use `savvy::log::env_logger()` to
+  output logs to R's stderr. Here's an example usage:
+
+  ```rust
+  use savvy::savvy_init;
+  use savvy_ffi::DllInfo;
+
+  #[savvy_init]
+  fn init_logger(dll_info: *mut DllInfo) -> savvy::Result<()> {
+      savvy::log::env_logger().init();
+      Ok(())
+  }
+  ```
+
 ### Breaking changes
 
 * `AltList` now loses `names` argument in `into_altrep()` for consistency.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ savvy-macro = { version = "0.6.2", path = "./savvy-macro" }
 once_cell = "1"
 num-complex = { version = "0.4.5", optional = true }
 
+log = { version = "0.4", optional = true }
+env_logger = { version = "0.11", default-features = false, optional = true }
+
 [features]
 default = []
 
@@ -27,11 +30,14 @@ complex = ["num-complex", "savvy-ffi/complex"]
 # Support ALTREP
 altrep = ["savvy-ffi/altrep"]
 
+# Support logger
+logger = ["log", "env_logger"]
+
 [build-dependencies]
 cc = "1"
 
 [package.metadata.docs.rs]
-features = ["complex", "altrep"]
+features = ["complex", "altrep", "logger"]
 
 [workspace.metadata.release]
 tag = false # do not create tags for individual crates (e.g. "savvy-cli-v0.2.5")

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -514,6 +514,11 @@ SEXP savvy_fun_mod1__impl(void) {
     return handle_result(res);
 }
 
+SEXP savvy_init_logger__impl(DllInfo* dll_info) {
+    SEXP res = savvy_init_logger__ffi(dll_info);
+    return handle_result(res);
+}
+
 SEXP savvy_fun_mod1_1_foo__impl(void) {
     SEXP res = savvy_fun_mod1_1_foo__ffi();
     return handle_result(res);
@@ -728,4 +733,5 @@ void R_init_savvyExamples(DllInfo *dll) {
 
     // Functions for initialzation, if any.
     savvy_init_altrep_class__impl(dll);
+    savvy_init_logger__impl(dll);
 }

--- a/R-package/src/rust/Cargo.toml
+++ b/R-package/src/rust/Cargo.toml
@@ -7,9 +7,13 @@ edition = "2021"
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-savvy = { path = "../../../", features = ["complex", "altrep"] }
+savvy = { path = "../../../", features = ["complex", "altrep", "logger"] }
 # for calling Rf_errorcall() to test error handling
 savvy-ffi = { path = "../../../savvy-ffi" }
+
+log = "0.4"
+env_logger = { version = "0.11", default-features = false }
+
 
 [profile.release]
 # By default, on release build, savvy terminates the R session when a panic

--- a/R-package/src/rust/api.h
+++ b/R-package/src/rust/api.h
@@ -94,6 +94,7 @@ SEXP savvy_filter_complex_without_im__ffi(SEXP x);
 SEXP savvy_filter_logical_duplicates__ffi(SEXP x);
 SEXP savvy_filter_string_ascii__ffi(SEXP x);
 SEXP savvy_fun_mod1__ffi(void);
+SEXP savvy_init_logger__ffi(DllInfo* dll_info);
 SEXP savvy_fun_mod1_1_foo__ffi(void);
 
 // methods and associated functions for FooEnum

--- a/R-package/src/rust/src/attributes.rs
+++ b/R-package/src/rust/src/attributes.rs
@@ -39,7 +39,7 @@ fn get_attr_int(x: savvy::IntegerSexp, attr: &str) -> savvy::Result<savvy::Sexp>
 fn set_class_int() -> savvy::Result<savvy::Sexp> {
     let mut x = OwnedIntegerSexp::new(1)?;
 
-    x.set_class(&["foo", "bar"])?;
+    x.set_class(["foo", "bar"])?;
 
     x.into()
 }
@@ -49,7 +49,7 @@ fn set_names_int() -> savvy::Result<savvy::Sexp> {
     let x_vec = vec![1, 2];
     let mut x: OwnedIntegerSexp = x_vec.try_into()?;
 
-    x.set_names(&["foo", "bar"])?;
+    x.set_names(["foo", "bar"])?;
 
     x.into()
 }

--- a/R-package/src/rust/src/lib.rs
+++ b/R-package/src/rust/src/lib.rs
@@ -23,6 +23,8 @@ mod mod1;
 // This should not be parsed
 // mod mod2;
 
+mod log;
+
 use savvy::{r_print, savvy, OwnedListSexp};
 
 use savvy::{

--- a/R-package/src/rust/src/log.rs
+++ b/R-package/src/rust/src/log.rs
@@ -1,0 +1,8 @@
+use savvy::savvy_init;
+use savvy_ffi::DllInfo;
+
+#[savvy_init]
+fn init_logger(dll_info: *mut DllInfo) -> savvy::Result<()> {
+    savvy::log::env_logger().init();
+    Ok(())
+}

--- a/src/altrep/altinteger.rs
+++ b/src/altrep/altinteger.rs
@@ -123,6 +123,8 @@ pub fn register_altinteger_class<T: AltInteger>(
             0,
         );
 
+        crate::log::debug!("A {} object is materialized", T::CLASS_NAME);
+
         // Cache the materialized data in data2.
         unsafe { R_set_altrep_data2(*x, new) };
 

--- a/src/altrep/altinteger.rs
+++ b/src/altrep/altinteger.rs
@@ -138,11 +138,15 @@ pub fn register_altinteger_class<T: AltInteger>(
         mut x: SEXP,
         _deep_copy: Rboolean,
     ) -> SEXP {
+        crate::log::trace!("A {} object is duplicated", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_duplicate(materialized) }
     }
 
     unsafe extern "C" fn altrep_coerce<T: AltInteger>(mut x: SEXP, sexp_type: SEXPTYPE) -> SEXP {
+        crate::log::trace!("A {} object is coerced", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_coerceVector(materialized, sexp_type) }
     }
@@ -159,10 +163,14 @@ pub fn register_altinteger_class<T: AltInteger>(
         x: SEXP,
         _writable: Rboolean,
     ) -> *mut c_void {
+        crate::log::trace!("DATAPTR({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, true)
     }
 
     unsafe extern "C" fn altvec_dataptr_or_null<T: AltInteger>(x: SEXP) -> *const c_void {
+        crate::log::trace!("DATAPTR_OR_NULL({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, false)
     }
 
@@ -195,6 +203,8 @@ pub fn register_altinteger_class<T: AltInteger>(
     }
 
     unsafe extern "C" fn altinteger_elt<T: AltInteger>(mut x: SEXP, i: R_xlen_t) -> c_int {
+        crate::log::trace!("INTEGER_ELT({}, {i}) is called", T::CLASS_NAME);
+
         if let Some(materialized) = get_materialized_sexp::<T>(&mut x, false) {
             unsafe { INTEGER_ELT(materialized, i) }
         } else {

--- a/src/altrep/altlist.rs
+++ b/src/altrep/altlist.rs
@@ -117,11 +117,15 @@ pub fn register_altlist_class<T: AltList>(
     }
 
     unsafe extern "C" fn altrep_duplicate<T: AltList>(mut x: SEXP, _deep_copy: Rboolean) -> SEXP {
+        crate::log::trace!("A {} object is duplicated", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_duplicate(materialized) }
     }
 
     unsafe extern "C" fn altrep_coerce<T: AltList>(mut x: SEXP, sexp_type: SEXPTYPE) -> SEXP {
+        crate::log::trace!("A {} object is coerced", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_coerceVector(materialized, sexp_type) }
     }
@@ -136,10 +140,14 @@ pub fn register_altlist_class<T: AltList>(
     }
 
     unsafe extern "C" fn altvec_dataptr<T: AltList>(x: SEXP, _writable: Rboolean) -> *mut c_void {
+        crate::log::trace!("DATAPTR({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, true)
     }
 
     unsafe extern "C" fn altvec_dataptr_or_null<T: AltList>(x: SEXP) -> *const c_void {
+        crate::log::trace!("DATAPTR_OR_NULL({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, false)
     }
 
@@ -172,6 +180,8 @@ pub fn register_altlist_class<T: AltList>(
     }
 
     unsafe extern "C" fn altlist_elt<T: AltList>(mut x: SEXP, i: R_xlen_t) -> SEXP {
+        crate::log::trace!("VECTOR_ELT({}, {i}) is called", T::CLASS_NAME);
+
         if let Some(materialized) = get_materialized_sexp::<T>(&mut x, false) {
             unsafe { VECTOR_ELT(materialized, i) }
         } else {

--- a/src/altrep/altlist.rs
+++ b/src/altrep/altlist.rs
@@ -105,6 +105,8 @@ pub fn register_altlist_class<T: AltList>(
             unsafe { SET_VECTOR_ELT(new, i as _, self_.elt(i).0) };
         }
 
+        crate::log::debug!("A {} object is materialized", T::CLASS_NAME);
+
         // Cache the materialized data in data2.
         unsafe { R_set_altrep_data2(*x, new) };
 

--- a/src/altrep/altlogical.rs
+++ b/src/altrep/altlogical.rs
@@ -138,11 +138,15 @@ pub fn register_altlogical_class<T: AltLogical>(
         mut x: SEXP,
         _deep_copy: Rboolean,
     ) -> SEXP {
+        crate::log::trace!("A {} object is duplicated", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_duplicate(materialized) }
     }
 
     unsafe extern "C" fn altrep_coerce<T: AltLogical>(mut x: SEXP, sexp_type: SEXPTYPE) -> SEXP {
+        crate::log::trace!("A {} object is coerced", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_coerceVector(materialized, sexp_type) }
     }
@@ -159,10 +163,14 @@ pub fn register_altlogical_class<T: AltLogical>(
         x: SEXP,
         _writable: Rboolean,
     ) -> *mut c_void {
+        crate::log::trace!("DATAPTR({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, true)
     }
 
     unsafe extern "C" fn altvec_dataptr_or_null<T: AltLogical>(x: SEXP) -> *const c_void {
+        crate::log::trace!("DATAPTR_OR_NULL({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, false)
     }
 
@@ -195,6 +203,8 @@ pub fn register_altlogical_class<T: AltLogical>(
     }
 
     unsafe extern "C" fn altlogical_elt<T: AltLogical>(mut x: SEXP, i: R_xlen_t) -> c_int {
+        crate::log::trace!("LOGICAL_ELT({}, {i}) is called", T::CLASS_NAME);
+
         if let Some(materialized) = get_materialized_sexp::<T>(&mut x, false) {
             unsafe { LOGICAL_ELT(materialized, i) }
         } else {

--- a/src/altrep/altlogical.rs
+++ b/src/altrep/altlogical.rs
@@ -123,6 +123,8 @@ pub fn register_altlogical_class<T: AltLogical>(
             0,
         );
 
+        crate::log::debug!("A {} object is materialized", T::CLASS_NAME);
+
         // Cache the materialized data in data2.
         unsafe { R_set_altrep_data2(*x, new) };
 

--- a/src/altrep/altreal.rs
+++ b/src/altrep/altreal.rs
@@ -115,6 +115,8 @@ pub fn register_altreal_class<T: AltReal>(
 
         self_.copy_to(unsafe { std::slice::from_raw_parts_mut(REAL(new), len) }, 0);
 
+        crate::log::debug!("A {} object is materialized", T::CLASS_NAME);
+
         // Cache the materialized data in data2.
         unsafe { R_set_altrep_data2(*x, new) };
 

--- a/src/altrep/altreal.rs
+++ b/src/altrep/altreal.rs
@@ -127,11 +127,15 @@ pub fn register_altreal_class<T: AltReal>(
     }
 
     unsafe extern "C" fn altrep_duplicate<T: AltReal>(mut x: SEXP, _deep_copy: Rboolean) -> SEXP {
+        crate::log::trace!("A {} object is duplicated", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_duplicate(materialized) }
     }
 
     unsafe extern "C" fn altrep_coerce<T: AltReal>(mut x: SEXP, sexp_type: SEXPTYPE) -> SEXP {
+        crate::log::trace!("A {} object is coerced", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_coerceVector(materialized, sexp_type) }
     }
@@ -145,10 +149,14 @@ pub fn register_altreal_class<T: AltReal>(
     }
 
     unsafe extern "C" fn altvec_dataptr<T: AltReal>(x: SEXP, _writable: Rboolean) -> *mut c_void {
+        crate::log::trace!("DATAPTR({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, true)
     }
 
     unsafe extern "C" fn altvec_dataptr_or_null<T: AltReal>(x: SEXP) -> *const c_void {
+        crate::log::trace!("DATAPTR_OR_NULL({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, false)
     }
 
@@ -181,6 +189,8 @@ pub fn register_altreal_class<T: AltReal>(
     }
 
     unsafe extern "C" fn altreal_elt<T: AltReal>(mut x: SEXP, i: R_xlen_t) -> f64 {
+        crate::log::trace!("REAL_ELT({}, {i}) is called", T::CLASS_NAME);
+
         if let Some(materialized) = get_materialized_sexp::<T>(&mut x, false) {
             unsafe { REAL_ELT(materialized, i) }
         } else {

--- a/src/altrep/altstring.rs
+++ b/src/altrep/altstring.rs
@@ -121,11 +121,15 @@ pub fn register_altstring_class<T: AltString>(
     }
 
     unsafe extern "C" fn altrep_duplicate<T: AltString>(mut x: SEXP, _deep_copy: Rboolean) -> SEXP {
+        crate::log::trace!("A {} object is duplicated", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_duplicate(materialized) }
     }
 
     unsafe extern "C" fn altrep_coerce<T: AltString>(mut x: SEXP, sexp_type: SEXPTYPE) -> SEXP {
+        crate::log::trace!("A {} object is coerced", T::CLASS_NAME);
+
         let materialized = get_materialized_sexp::<T>(&mut x, true).expect("Must have result");
         unsafe { Rf_coerceVector(materialized, sexp_type) }
     }
@@ -140,10 +144,14 @@ pub fn register_altstring_class<T: AltString>(
     }
 
     unsafe extern "C" fn altvec_dataptr<T: AltString>(x: SEXP, _writable: Rboolean) -> *mut c_void {
+        crate::log::trace!("DATAPTR({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, true)
     }
 
     unsafe extern "C" fn altvec_dataptr_or_null<T: AltString>(x: SEXP) -> *const c_void {
+        crate::log::trace!("DATAPTR_OR_NULL({}) is called", T::CLASS_NAME);
+
         altvec_dataptr_inner::<T>(x, false)
     }
 
@@ -176,6 +184,8 @@ pub fn register_altstring_class<T: AltString>(
     }
 
     unsafe extern "C" fn altstring_elt<T: AltString>(mut x: SEXP, i: R_xlen_t) -> SEXP {
+        crate::log::trace!("STRING_ELT({}, {i}) is called", T::CLASS_NAME);
+
         if let Some(materialized) = get_materialized_sexp::<T>(&mut x, false) {
             unsafe { STRING_ELT(materialized, i) }
         } else {

--- a/src/altrep/altstring.rs
+++ b/src/altrep/altstring.rs
@@ -109,6 +109,8 @@ pub fn register_altstring_class<T: AltString>(
             };
         }
 
+        crate::log::debug!("A {} object is materialized", T::CLASS_NAME);
+
         // Cache the materialized data in data2.
         unsafe { R_set_altrep_data2(*x, new) };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ pub mod unwind_protect;
 #[cfg(feature = "altrep")]
 pub mod altrep;
 
+pub mod log;
+
 use std::os::raw::c_char;
 
 pub use error::{Error, Result};

--- a/src/log.rs
+++ b/src/log.rs
@@ -8,7 +8,17 @@ macro_rules! debug {
     ($($arg:tt)+) => {};
 }
 
-pub(crate) use debug;
+#[cfg(feature = "logger")]
+macro_rules! trace {
+    ($($arg:tt)+) => (log::trace!($($arg)+))
+}
+
+#[cfg(not(feature = "logger"))]
+macro_rules! trace {
+    ($($arg:tt)+) => {};
+}
+
+pub(crate) use {debug, trace};
 
 #[cfg(feature = "logger")]
 pub fn env_logger() -> env_logger::Builder {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,20 @@
+#[cfg(feature = "logger")]
+macro_rules! debug {
+    ($($arg:tt)+) => (log::debug!($($arg)+))
+}
+
+#[cfg(not(feature = "logger"))]
+macro_rules! debug {
+    ($($arg:tt)+) => {};
+}
+
+pub(crate) use debug;
+
+#[cfg(feature = "logger")]
+pub fn env_logger() -> env_logger::Builder {
+    let r_stdout = Box::new(crate::io::r_stdout());
+    let target = env_logger::Target::Pipe(r_stdout);
+    let mut builder = env_logger::builder();
+    builder.target(target);
+    builder
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -12,8 +12,8 @@ pub(crate) use debug;
 
 #[cfg(feature = "logger")]
 pub fn env_logger() -> env_logger::Builder {
-    let r_stdout = Box::new(crate::io::r_stdout());
-    let target = env_logger::Target::Pipe(r_stdout);
+    let r_stderr = Box::new(crate::io::r_stderr());
+    let target = env_logger::Target::Pipe(r_stderr);
     let mut builder = env_logger::builder();
     builder.target(target);
     builder


### PR DESCRIPTION
``` rust
use savvy::savvy_init;
use savvy_ffi::DllInfo;

#[savvy_init]
fn init_logger(dll_info: *mut DllInfo) -> savvy::Result<()> {
    savvy::log::env_logger().init();
    Ok(())
}
```

``` r
x <- altint()
c(x)
#> [DEBUG savvy::altrep::altinteger] A MyAltInt object is materialized
#> [1] 1 2 3
```