### PR TITLE
Handle `NULL` on an optonal struct argument

### DIFF
--- a/R-package/R/000-wrappers.R
+++ b/R-package/R/000-wrappers.R
@@ -11,6 +11,10 @@ NULL
 
 # Check class and extract the external pointer embedded in the environment
 .savvy_extract_ptr <- function(e, class) {
+  if(is.null(e)) {
+    return(NULL)
+  }
+
   if(inherits(e, class)) {
     e$.ptr
   } else {

--- a/R-package/R/000-wrappers.R
+++ b/R-package/R/000-wrappers.R
@@ -546,6 +546,12 @@ default_value_vec <- function(x = NULL) {
 }
 
 
+default_value_struct <- function(x = NULL) {
+  x <- .savvy_extract_ptr(x, "FooWithDefault")
+  .Call(savvy_default_value_struct__impl, x)
+}
+
+
 filter_integer_odd <- function(x) {
   .Call(savvy_filter_integer_odd__impl, x)
 }

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -524,6 +524,11 @@ SEXP savvy_default_value_vec__impl(SEXP x) {
     return handle_result(res);
 }
 
+SEXP savvy_default_value_struct__impl(SEXP x) {
+    SEXP res = savvy_default_value_struct__ffi(x);
+    return handle_result(res);
+}
+
 SEXP savvy_filter_integer_odd__impl(SEXP x) {
     SEXP res = savvy_filter_integer_odd__ffi(x);
     return handle_result(res);
@@ -762,6 +767,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"savvy_print_numeric__impl", (DL_FUNC) &savvy_print_numeric__impl, 1},
     {"savvy_default_value_scalar__impl", (DL_FUNC) &savvy_default_value_scalar__impl, 1},
     {"savvy_default_value_vec__impl", (DL_FUNC) &savvy_default_value_vec__impl, 1},
+    {"savvy_default_value_struct__impl", (DL_FUNC) &savvy_default_value_struct__impl, 1},
     {"savvy_filter_integer_odd__impl", (DL_FUNC) &savvy_filter_integer_odd__impl, 1},
     {"savvy_filter_real_negative__impl", (DL_FUNC) &savvy_filter_real_negative__impl, 1},
     {"savvy_filter_complex_without_im__impl", (DL_FUNC) &savvy_filter_complex_without_im__impl, 1},

--- a/R-package/src/rust/api.h
+++ b/R-package/src/rust/api.h
@@ -96,6 +96,7 @@ SEXP savvy_times_two_numeric_i32_scalar__ffi(SEXP x);
 SEXP savvy_print_numeric__ffi(SEXP x);
 SEXP savvy_default_value_scalar__ffi(SEXP x);
 SEXP savvy_default_value_vec__ffi(SEXP x);
+SEXP savvy_default_value_struct__ffi(SEXP x);
 SEXP savvy_filter_integer_odd__ffi(SEXP x);
 SEXP savvy_filter_real_negative__ffi(SEXP x);
 SEXP savvy_filter_complex_without_im__ffi(SEXP x);

--- a/R-package/src/rust/src/optional_arg.rs
+++ b/R-package/src/rust/src/optional_arg.rs
@@ -33,3 +33,12 @@ impl FooWithDefault {
         x.unwrap_or(-1).try_into()
     }
 }
+
+#[savvy]
+fn default_value_struct(x: Option<&FooWithDefault>) -> savvy::Result<Sexp> {
+    if let Some(x) = x {
+        x.default_value.try_into()
+    } else {
+        (-1).try_into()
+    }
+}

--- a/R-package/tests/testthat/test-optional_args.R
+++ b/R-package/tests/testthat/test-optional_args.R
@@ -10,4 +10,7 @@ test_that("optional arg works", {
   x <- FooWithDefault$new(-100L)
   expect_equal(x$default_value_method(10L), 10L)
   expect_equal(x$default_value_method(), -100L)
+
+  expect_equal(default_value_struct(x), -100L)
+  expect_equal(default_value_struct(), -1L)
 })

--- a/savvy-bindgen/src/gen/r.rs
+++ b/savvy-bindgen/src/gen/r.rs
@@ -352,6 +352,10 @@ NULL
 
 # Check class and extract the external pointer embedded in the environment
 .savvy_extract_ptr <- function(e, class) {{
+  if(is.null(e)) {{
+    return(NULL)
+  }}
+
   if(inherits(e, class)) {{
     e$.ptr
   }} else {{


### PR DESCRIPTION
Fix #255