### PR TITLE
refactor(bindgen): remove tab spaces

### DIFF
--- a/savvy-bindgen/src/gen/r.rs
+++ b/savvy-bindgen/src/gen/r.rs
@@ -210,8 +210,8 @@ fn generate_r_impl_for_impl(
         r#"{wrap_fn_name} <- function(ptr) {{
   e <- new.env(parent = emptyenv())
   e$.ptr <- ptr
-  {methods}
-  
+{methods}
+
   class(e) <- "{class_r}"
   e
 }}


### PR DESCRIPTION
I was just wondering about the spaces.

before:

```r
.savvy_wrap_RGlareDbConnection <- function(ptr) {
  e <- new.env(parent = emptyenv())
  e$.ptr <- ptr
    e$sql <- RGlareDbConnection_sql(ptr)
  e$prql <- RGlareDbConnection_prql(ptr)
  e$execute <- RGlareDbConnection_execute(ptr)
  
  class(e) <- "RGlareDbConnection"
  e
}
```

after:

```r
.savvy_wrap_RGlareDbConnection <- function(ptr) {
  e <- new.env(parent = emptyenv())
  e$.ptr <- ptr
  e$sql <- RGlareDbConnection_sql(ptr)
  e$prql <- RGlareDbConnection_prql(ptr)
  e$execute <- RGlareDbConnection_execute(ptr)

  class(e) <- "RGlareDbConnection"
  e
}
```

I'm afraid I just edited it on GitHub, so if you have any snapshot tests, etc., I'd appreciate it if you could update it.