### PR TITLE
Properly use the read-only version of API

### DIFF
--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -187,7 +187,7 @@ extern "C" {
 
 // List
 extern "C" {
-    pub fn DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
+    pub fn DATAPTR_RO(x: SEXP) -> *const ::std::os::raw::c_void; // TODO: replace this to VECTOR_PTR_RO()
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
     pub fn SET_VECTOR_ELT(x: SEXP, i: R_xlen_t, v: SEXP) -> SEXP;
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -136,7 +136,7 @@ fn show() -> Result<(), DynError> {
         .allowlist_function("R_CHAR")
         .allowlist_function("Rf_mkCharLenCE")
         // List
-        .allowlist_function("DATAPTR")
+        .allowlist_function("DATAPTR_RO")
         .allowlist_function("VECTOR_ELT")
         .allowlist_function("SET_VECTOR_ELT")
         // External pointer


### PR DESCRIPTION
* Do not cast the result of `STRING_PTR_RO` to `*mut T`; remove `Dataptr` method from `AltString`.
* Use `DATAPTR_RO` instead of `DATAPTR` (this should be `VECTOR_PTR_RO`, but since it's the API only available on R-deve, `DATAPTR_RO` is more handy for now).