### PR TITLE
Reject lifetimed struct

### DIFF
--- a/savvy-bindgen/src/ir/savvy_struct.rs
+++ b/savvy-bindgen/src/ir/savvy_struct.rs
@@ -1,4 +1,4 @@
-use syn::parse_quote;
+use syn::{parse_quote, spanned::Spanned};
 
 use crate::extract_docs;
 
@@ -13,6 +13,13 @@ pub struct SavvyStruct {
 
 impl SavvyStruct {
     pub fn new(orig: &syn::ItemStruct) -> syn::Result<Self> {
+        if let Some(lt) = orig.generics.lifetimes().next() {
+            return Err(syn::Error::new(
+                lt.span(),
+                "#[savvy] macro doesn't support lifetime",
+            ));
+        }
+
         let mut attrs = orig.attrs.clone();
         // Remove #[savvy]
         attrs.retain(|attr| attr != &parse_quote!(#[savvy]));

--- a/savvy-macro/tests/cases/simple_cases.rs
+++ b/savvy-macro/tests/cases/simple_cases.rs
@@ -49,6 +49,10 @@ fn wrong_type_option_owned_int(x: Option<OwnedIntegerSexp>) -> savvy::Result<()>
     Ok(())
 }
 
+// lifetime is not supported
+#[savvy]
+struct Foo<'a>(External::Bar<'a>);
+
 // only fieldless enums is supported
 #[savvy]
 enum Foo {

--- a/savvy-macro/tests/cases/simple_cases.stderr
+++ b/savvy-macro/tests/cases/simple_cases.stderr
@@ -60,32 +60,38 @@ error: `Owned-` types are not allowed here. Did you mean `IntegerSexp`?
 48 | fn wrong_type_option_owned_int(x: Option<OwnedIntegerSexp>) -> savvy::Result<()> {
    |                                          ^^^^^^^^^^^^^^^^
 
-error: savvy only supports a fieldless enum
-  --> tests/cases/simple_cases.rs:55:6
+error: #[savvy] macro doesn't support lifetime
+  --> tests/cases/simple_cases.rs:54:12
    |
-55 |     A(i32),
+54 | struct Foo<'a>(External::Bar<'a>);
+   |            ^^
+
+error: savvy only supports a fieldless enum
+  --> tests/cases/simple_cases.rs:59:6
+   |
+59 |     A(i32),
    |      ^^^^^
 
 error: savvy doesn't support an enum with discreminant
-  --> tests/cases/simple_cases.rs:63:9
+  --> tests/cases/simple_cases.rs:67:9
    |
-63 |     B = 100,
+67 |     B = 100,
    |         ^^^
 
 error: DllInfo must be `*mut DllInfo`
-  --> tests/cases/simple_cases.rs:67:23
+  --> tests/cases/simple_cases.rs:71:23
    |
-67 | fn init_wrong_type(x: DllInfo) -> savvy::Result<()> {
+71 | fn init_wrong_type(x: DllInfo) -> savvy::Result<()> {
    |                       ^^^^^^^
 
 error: DllInfo must be `*mut DllInfo`
-  --> tests/cases/simple_cases.rs:72:24
+  --> tests/cases/simple_cases.rs:76:24
    |
-72 | fn init_wrong_type2(x: *const DllInfo) -> savvy::Result<()> {
+76 | fn init_wrong_type2(x: *const DllInfo) -> savvy::Result<()> {
    |                        ^^^^^^^^^^^^^^
 
 error: #[savvy_init] can be used only on a function that takes `*mut DllInfo`
-  --> tests/cases/simple_cases.rs:77:41
+  --> tests/cases/simple_cases.rs:81:41
    |
-77 | fn init_wrong_type3(x: *mut DllInfo, y: i32) -> savvy::Result<()> {
+81 | fn init_wrong_type3(x: *mut DllInfo, y: i32) -> savvy::Result<()> {
    |                                         ^^^


### PR DESCRIPTION
Show better error message for https://github.com/yutannihilation/savvy/issues/281

```
error: #[savvy] macro doesn't support lifetime
  --> tests/cases/simple_cases.rs:54:12
   |
54 | struct Foo<'a>(External::Bar<'a>);
   |            ^^
```