### PR TITLE
Use `std::panic::PanicHookInfo` for Rust >=1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num-complex = { version = "0.4.5", optional = true }
 
 log = { version = "0.4", optional = true }
 env_logger = { version = "0.11", default-features = false, optional = true }
+rustversion = "1.0"
 
 [features]
 default = []

--- a/src/panic_hook.rs
+++ b/src/panic_hook.rs
@@ -1,4 +1,11 @@
-pub fn panic_hook(panic_info: &std::panic::PanicInfo) {
+// PanicInfo is deprecated since 1.82 (PanicHookInfo exists since 1.81)
+// cf. https://github.com/rust-lang/rust/pull/115974/
+#[rustversion::since(1.81)]
+type PanicHookInfo<'a> = std::panic::PanicHookInfo<'a>;
+#[rustversion::before(1.81)]
+type PanicHookInfo<'a> = std::panic::PanicInfo<'a>;
+
+pub fn panic_hook(panic_info: &PanicHookInfo) {
     // Add indent
     let panic_info_indented = format!("{panic_info}")
         .lines()


### PR DESCRIPTION
Close #282 

I might want to add some different implementation for `PanicHookInfo` when it gets more features, but this should be suffice for now to avoid the deprecation warning.