### PR TITLE
Remove `Rf_findVarInFrame`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### Minor Improvements
+
+* Remove the use of non-API call `Rf_findVarInFrame`.
+
 ## [v0.6.6] (2024-09-04)
 
 ### Bug fixes

--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -222,7 +222,6 @@ extern "C" {
     pub fn Rf_isEnvironment(arg1: SEXP) -> Rboolean;
     pub fn Rf_eval(arg1: SEXP, arg2: SEXP) -> SEXP;
     pub fn Rf_defineVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
-    pub fn Rf_findVarInFrame(arg1: SEXP, arg2: SEXP) -> SEXP;
     pub fn R_existsVarInFrame(arg1: SEXP, arg2: SEXP) -> Rboolean;
 
     pub static mut R_GlobalEnv: SEXP;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -159,7 +159,6 @@ fn show() -> Result<(), DynError> {
         .allowlist_function("Rf_isEnvironment")
         .allowlist_function("Rf_eval")
         .allowlist_var("R_GlobalEnv")
-        .allowlist_function("Rf_findVarInFrame")
         .allowlist_function("R_existsVarInFrame")
         .allowlist_function("Rf_defineVar")
         .allowlist_var("R_UnboundValue")


### PR DESCRIPTION
This replaces `Rf_findVarInFrame()` with `R_existsVarInFrame()` and `Rf_eval()`. This implementation isn't very efficient, but since savvy is not very eager to support environment, this should be enough for now. While I could use `cfg` to use different implementation for R >4.5 where `R_getVar()` is available, I chose to avoid make the implementation complex.