### PR TITLE
Use PanicHookInfo in savvy-cli

### DIFF
--- a/savvy-bindgen/src/parse_file.rs
+++ b/savvy-bindgen/src/parse_file.rs
@@ -411,7 +411,7 @@ pub fn generate_test_code(parsed_results: &Vec<ParsedResult>) -> String {
         #[allow(unused_imports)]
         use savvy::savvy;
 
-        pub(crate) fn savvy_show_error(code: &str, label: &str, location: &str, panic_info: &std::panic::PanicInfo) {
+        pub(crate) fn savvy_show_error(code: &str, label: &str, location: &str, panic_info: &std::panic::PanicHookInfo) {
             let mut msg: Vec<String> = Vec::new();
             let orig_msg = panic_info.to_string();
             let mut lines = orig_msg.lines();

--- a/savvy-cli/Cargo.toml
+++ b/savvy-cli/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 
-# clap requires 1.74
-rust-version = "1.74"
+# PanicHookInfo is introduced in 1.81
+rust-version = "1.81"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Close #282 

I think I can introduce a `#[rustversion]` switch here, but, for the sake of simplicity, I chose to bump the MSRV of savvy-cli. This doesn't affect savvy.