### PR TITLE
fix(bindgen/template): fix shell commands

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -6,8 +6,8 @@
 # Even when `cargo` is on `PATH`, `rustc` might not in some cases. This adds
 # ~/.cargo/bin to PATH to address such cases. Note that is not always available
 # (e.g. or on Ubuntu with Rust installed via APT).
-if [ -e "$(HOME)/.cargo/bin" ]; then
-  export PATH="$(PATH):$(HOME)/.cargo/bin"
+if [ -d "${HOME}/.cargo/bin" ]; then
+  export PATH="${PATH}:${HOME}/.cargo/bin"
 fi
 
 CARGO_VERSION="$(cargo --version)"

--- a/savvy-bindgen/src/gen/templates/configure
+++ b/savvy-bindgen/src/gen/templates/configure
@@ -6,8 +6,8 @@
 # Even when `cargo` is on `PATH`, `rustc` might not in some cases. This adds
 # ~/.cargo/bin to PATH to address such cases. Note that is not always available
 # (e.g. or on Ubuntu with Rust installed via APT).
-if [ -e "$(HOME)/.cargo/bin" ]; then
-  export PATH="$(PATH):$(HOME)/.cargo/bin"
+if [ -d "${HOME}/.cargo/bin" ]; then
+  export PATH="${PATH}:${HOME}/.cargo/bin"
 fi
 
 CARGO_VERSION="$(cargo --version)"


### PR DESCRIPTION
- Perhaps `-d` is more appropriate here than `-e`?
- This is not a Makefile, so if we leave these as `$()`, we may get an error because there are no commands `HOME` or `PATH`.