### PR TITLE
Reject the conversion from >2^53 to usize 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### Bug fixes
+
+* `NumericScalar::as_usize()` and `NumericSexp::iter_usize()` now fail if the
+  number is larger than `2^53 - 1` because this is the maximum number that can
+  be safely converted to usize.
+
 ## [v0.7.0] (2024-10-20)
 
 ### Breaking Change

--- a/R-package/tests/testthat/test-numeric.R
+++ b/R-package/tests/testthat/test-numeric.R
@@ -39,7 +39,7 @@ test_that("NumericSexp works for usize conversions", {
   # f64 to usize
   expect_equal(
     # 2147483647 = .Machine$integer.max
-    usize_to_string(c(0.0, 10.0, 2147483648.0, 9007199254740991.0)),
+    usize_to_string(c(0.0, 10.0, 2147483648.0, 9007199254740991)),
     c("0", "10", "2147483648", "9007199254740991")
   )
 
@@ -82,7 +82,7 @@ test_that("NumericScalar works for usize conversions", {
   expect_equal(usize_to_string_scalar(10.0), "10")
   # 2147483647 = .Machine$integer.max
   expect_equal(usize_to_string_scalar(2147483648.0), "2147483648")
-  expect_equal(usize_to_string_scalar(9007199254740991.0), "9007199254740991")
+  expect_equal(usize_to_string_scalar(9007199254740991), "9007199254740991")
 
   # error cases
   expect_error(usize_to_string_scalar(NA_integer_))

--- a/R-package/tests/testthat/test-numeric.R
+++ b/R-package/tests/testthat/test-numeric.R
@@ -39,8 +39,8 @@ test_that("NumericSexp works for usize conversions", {
   # f64 to usize
   expect_equal(
     # 2147483647 = .Machine$integer.max
-    usize_to_string(c(0.0, 10.0, 2147483648.0)),
-    c("0", "10", "2147483648")
+    usize_to_string(c(0.0, 10.0, 2147483648.0, 9007199254740991.0)),
+    c("0", "10", "2147483648", "9007199254740991")
   )
 
   # error cases
@@ -50,6 +50,7 @@ test_that("NumericSexp works for usize conversions", {
   expect_error(usize_to_string(NaN))
   expect_error(usize_to_string(-1L))
   expect_error(usize_to_string(-1.0))
+  expect_error(usize_to_string_scalar(9007199254740992.0))
 })
 
 
@@ -81,6 +82,7 @@ test_that("NumericScalar works for usize conversions", {
   expect_equal(usize_to_string_scalar(10.0), "10")
   # 2147483647 = .Machine$integer.max
   expect_equal(usize_to_string_scalar(2147483648.0), "2147483648")
+  expect_equal(usize_to_string_scalar(9007199254740991.0), "9007199254740991")
 
   # error cases
   expect_error(usize_to_string_scalar(NA_integer_))
@@ -89,4 +91,5 @@ test_that("NumericScalar works for usize conversions", {
   expect_error(usize_to_string_scalar(NaN))
   expect_error(usize_to_string_scalar(-1L))
   expect_error(usize_to_string_scalar(-1.0))
+  expect_error(usize_to_string_scalar(9007199254740992.0))
 })

--- a/src/sexp/numeric.rs
+++ b/src/sexp/numeric.rs
@@ -8,7 +8,9 @@ const I32MAX: f64 = i32::MAX as f64;
 const I32MIN: f64 = i32::MIN as f64;
 
 // f64 can represent 2^53
-// cf. https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+//
+// cf. https://en.wikipedia.org/wiki/Double-precision_floating-point_format,
+//     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
 const F64_MAX_SIGFIG: f64 = (2_u64.pow(53) - 1) as f64;
 
 const TOLERANCE: f64 = 0.01; // This is super-tolerant than vctrs, but this should be sufficient.

--- a/src/sexp/numeric.rs
+++ b/src/sexp/numeric.rs
@@ -6,7 +6,11 @@ use crate::{IntegerSexp, NotAvailableValue, RealSexp, Sexp};
 
 const I32MAX: f64 = i32::MAX as f64;
 const I32MIN: f64 = i32::MIN as f64;
-const USIZEMAX: f64 = usize::MAX as f64;
+
+// f64 can represent 2^53
+// cf. https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+const F64_MAX_SIGFIG: f64 = (2_u64.pow(53) - 1) as f64;
+
 const TOLERANCE: f64 = 0.01; // This is super-tolerant than vctrs, but this should be sufficient.
 
 fn try_cast_f64_to_i32(f: f64) -> crate::Result<i32> {
@@ -40,8 +44,8 @@ fn try_cast_i32_to_usize(i: i32) -> crate::error::Result<usize> {
 fn try_cast_f64_to_usize(f: f64) -> crate::Result<usize> {
     if f.is_na() || f.is_nan() {
         Err("cannot convert NA or NaN to usize".into())
-    } else if f.is_infinite() || !(0f64..=USIZEMAX).contains(&f) {
-        Err(format!("{f:?} is out of range for usize").into())
+    } else if f.is_infinite() || !(0f64..=F64_MAX_SIGFIG).contains(&f) {
+        Err(format!("{f:?} is out of range that can be safely converted to usize").into())
     } else if (f - f.round()).abs() > TOLERANCE {
         Err(format!("{f:?} is not integer-ish").into())
     } else {


### PR DESCRIPTION
This is a follow-up of #311 

A double precision floating point number has 53-bit significand precision(ref: [Wikipedia](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)). So, if the number is equal to or larger than 2^53, it cannot be safely converted to u64.

It seems this is the strategy of JavaScript.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER