### PR TITLE
One-char typo fix to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Currently, it also requires
 * `R` is on PATH
 * [pkgbuild R package][pkgbuild] is installed
 
-[okgbuild]: https://pkgbuild.r-lib.org/
+[pkgbuild]: https://pkgbuild.r-lib.org/
 
 #### R package for testing
 


### PR DESCRIPTION
The link to `pkgbuild` was borked as its markdown definition was (accidentally, I presume) set as `okgbuild`.