### PR TITLE
Handle `DEBUG` envvar in configure script rather than in Makevars

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -39,7 +39,6 @@ else
   PROFILE=release
 fi
 
-
 sed \
   -e "s/@TARGET@/${TARGET}/" \
   -e "s/@PROFILE@/${PROFILE}/" \

--- a/R-package/configure
+++ b/R-package/configure
@@ -32,4 +32,15 @@ if [ "$(uname)" = "Emscripten" ]; then
   TARGET="wasm32-unknown-emscripten"
 fi
 
-sed -e "s/@TARGET@/${TARGET}/" src/Makevars.in > src/Makevars
+# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
+if [ "${DEBUG}" = "true" ]; then
+  PROFILE=dev
+else
+  PROFILE=release
+fi
+
+
+sed \
+  -e "s/@TARGET@/${TARGET}/" \
+  -e "s/@PROFILE@/${PROFILE}/" \
+  src/Makevars.in > src/Makevars

--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -21,4 +21,14 @@ RUSTC_VERSION="$(rustc --version || true)"
 echo "using Rust package manager: '${CARGO_VERSION}'"
 echo "using Rust compiler: '${RUSTC_VERSION}'"
 
-sed -e "s/@TARGET@/x86_64-pc-windows-gnu/" src/Makevars.win.in > src/Makevars.win
+# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
+if [ "${DEBUG}" = "true" ]; then
+  PROFILE=dev
+else
+  PROFILE=release
+fi
+
+sed \
+  -e "s/@TARGET@/x86_64-pc-windows-gnu/" \
+  -e "s/@PROFILE@/${PROFILE}/" \
+  src/Makevars.win.in > src/Makevars.win

--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -1,7 +1,6 @@
 TARGET = @TARGET@
 
-# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
-PROFILE = $(subst x,release,$(subst truex,dev,$(DEBUG)x))
+PROFILE = @PROFILE@
 
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -1,7 +1,6 @@
 TARGET = @TARGET@
 
-# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
-PROFILE = $(subst x,release,$(subst truex,dev,$(DEBUG)x))
+PROFILE = @PROFILE@
 
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))

--- a/savvy-bindgen/src/gen/templates/Makevars.in
+++ b/savvy-bindgen/src/gen/templates/Makevars.in
@@ -1,7 +1,6 @@
 TARGET = @TARGET@
 
-# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
-PROFILE = $(subst x,release,$(subst truex,dev,$(DEBUG)x))
+PROFILE = @PROFILE@
 
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))

--- a/savvy-bindgen/src/gen/templates/Makevars.win.in
+++ b/savvy-bindgen/src/gen/templates/Makevars.win.in
@@ -1,7 +1,6 @@
 TARGET = @TARGET@
 
-# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
-PROFILE = $(subst x,release,$(subst truex,dev,$(DEBUG)x))
+PROFILE = @PROFILE@
 
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))

--- a/savvy-bindgen/src/gen/templates/configure
+++ b/savvy-bindgen/src/gen/templates/configure
@@ -39,7 +39,6 @@ else
   PROFILE=release
 fi
 
-
 sed \
   -e "s/@TARGET@/${TARGET}/" \
   -e "s/@PROFILE@/${PROFILE}/" \

--- a/savvy-bindgen/src/gen/templates/configure
+++ b/savvy-bindgen/src/gen/templates/configure
@@ -32,4 +32,15 @@ if [ "$(uname)" = "Emscripten" ]; then
   TARGET="wasm32-unknown-emscripten"
 fi
 
-sed -e "s/@TARGET@/${TARGET}/" src/Makevars.in > src/Makevars
+# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
+if [ "${DEBUG}" = "true" ]; then
+  PROFILE=dev
+else
+  PROFILE=release
+fi
+
+
+sed \
+  -e "s/@TARGET@/${TARGET}/" \
+  -e "s/@PROFILE@/${PROFILE}/" \
+  src/Makevars.in > src/Makevars

--- a/savvy-bindgen/src/gen/templates/configure.win
+++ b/savvy-bindgen/src/gen/templates/configure.win
@@ -21,4 +21,14 @@ RUSTC_VERSION="$(rustc --version || true)"
 echo "using Rust package manager: '${CARGO_VERSION}'"
 echo "using Rust compiler: '${RUSTC_VERSION}'"
 
-sed -e "s/@TARGET@/x86_64-pc-windows-gnu/" src/Makevars.win.in > src/Makevars.win
+# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
+if [ "${DEBUG}" = "true" ]; then
+  PROFILE=dev
+else
+  PROFILE=release
+fi
+
+sed \
+  -e "s/@TARGET@/x86_64-pc-windows-gnu/" \
+  -e "s/@PROFILE@/${PROFILE}/" \
+  src/Makevars.win.in > src/Makevars.win


### PR DESCRIPTION
`subst` trick looks a bit too magical.