### PR TITLE
Use RUSTFLAGS to inject `--print=native-static-libs`

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -2,6 +2,9 @@ TARGET = @TARGET@
 
 PROFILE = @PROFILE@
 
+# Add flags if necessary
+RUSTFLAGS = 
+
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))
 STATLIB = $(LIBDIR)/libsimple_savvy.a
@@ -18,11 +21,12 @@ $(STATLIB):
 	# to set it here to ensure cargo can be invoked. It is appended to PATH and
 	# therefore is only used if cargo is absent from the user's PATH.
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+	  export CC="$(CC)" && \
+	  export CFLAGS="$(CFLAGS)" && \
+	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \
 	    cargo build $(CARGO_BUILD_ARGS); \
 	  else \
-	    export CC="$(CC)" && \
-	    export CFLAGS="$(CFLAGS)" && \
 	    export CARGO_PROFILE_DEV_PANIC="abort" && \
 	    export CARGO_PROFILE_RELEASE_PANIC="abort" && \
 	    cargo +nightly build $(CARGO_BUILD_ARGS) --target $(TARGET) -Zbuild-std=panic_abort,std; \

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -2,6 +2,9 @@ TARGET = @TARGET@
 
 PROFILE = @PROFILE@
 
+# Add flags if necessary
+RUSTFLAGS = 
+
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))
 STATLIB = $(LIBDIR)/libsimple_savvy.a
@@ -22,6 +25,9 @@ $(STATLIB):
 	mkdir -p $(LIBDIR)/libgcc_mock && touch $(LIBDIR)/libgcc_mock/libgcc_eh.a
 
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+	  export CC="$(CC)" && \
+	  export CFLAGS="$(CFLAGS)" && \
+	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  export LIBRARY_PATH="$${LIBRARY_PATH};$(LIBDIR)/libgcc_mock" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 

--- a/book/src/linkage.md
+++ b/book/src/linkage.md
@@ -32,18 +32,18 @@ pro-tip!
 
 > The `--print=native-static-libs` flag may help with this.
 
-You can run `cargo rustc` (not `cargo build`) with the option like this.
-You might need to add more options to match with the actual `cargo build`.
-On Windows, `--target x86_64-pc-windows-gnu` is needed.
+You can add this option to `src/Makevars.in` and `src/Makevars.win.in` via
+`RUSTFLAGS` envvar. Please edit this line.
 
-```sh
-cargo rustc --lib --manifest-path ./src/rust/Cargo.toml -- --print=native-static-libs
+``` diff
+  # Add flags if necessary
+- RUSTFLAGS = 
++ RUSTFLAGS = --print=native-static-libs
 ```
 
-Then, you'll see this note.
+Then, you'll find this note in the installation log.
 
 ```sh
-❯ cargo rustc --lib --manifest-path ./src/rust/Cargo.toml -- --print=native-static-libs
    Compiling ahash v0.8.11
    Compiling serde v1.0.210
    Compiling zerocopy v0.7.35
@@ -55,6 +55,9 @@ note: Link against the following native artifacts when linking against this stat
 note: native-static-libs: -framework CoreText -framework CoreGraphics -framework CoreFoundation -framework Foundation -lobjc -liconv -lSystem -lc -lm
 
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.17s
+   gcc -shared -L/usr/lib64/R/lib -Wl,-O1 -Wl,--sort-common -Wl,...
+   installing to /tmp/RtmpvQv8Ur/devtools_install_...
+   ** checking absolute paths in shared objects and dynamic libraries
 ```
 
 You can copy these flags to `cargo build`. Please be aware that this differs on

--- a/savvy-bindgen/src/gen/templates/Makevars.in
+++ b/savvy-bindgen/src/gen/templates/Makevars.in
@@ -2,6 +2,9 @@ TARGET = @TARGET@
 
 PROFILE = @PROFILE@
 
+# Add flags if necessary
+RUSTFLAGS = 
+
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))
 STATLIB = $(LIBDIR)/lib{}.a
@@ -18,11 +21,12 @@ $(STATLIB):
 	# to set it here to ensure cargo can be invoked. It is appended to PATH and
 	# therefore is only used if cargo is absent from the user's PATH.
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+	  export CC="$(CC)" && \
+	  export CFLAGS="$(CFLAGS)" && \
+	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \
 	    cargo build $(CARGO_BUILD_ARGS); \
 	  else \
-	    export CC="$(CC)" && \
-	    export CFLAGS="$(CFLAGS)" && \
 	    export CARGO_PROFILE_DEV_PANIC="abort" && \
 	    export CARGO_PROFILE_RELEASE_PANIC="abort" && \
 	    cargo +nightly build $(CARGO_BUILD_ARGS) --target $(TARGET) -Zbuild-std=panic_abort,std; \

--- a/savvy-bindgen/src/gen/templates/Makevars.win.in
+++ b/savvy-bindgen/src/gen/templates/Makevars.win.in
@@ -2,6 +2,9 @@ TARGET = @TARGET@
 
 PROFILE = @PROFILE@
 
+# Add flags if necessary
+RUSTFLAGS = 
+
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))
 STATLIB = $(LIBDIR)/lib{}.a
@@ -23,6 +26,9 @@ $(STATLIB):
 
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 	  export LIBRARY_PATH="$${{LIBRARY_PATH}};$(LIBDIR)/libgcc_mock" && \
+	  export CC="$(CC)" && \
+	  export CFLAGS="$(CFLAGS)" && \
+	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:


### PR DESCRIPTION
I use `cargo rustc --`, but extendr Discord told me `RUSTFLAGS` is better.