### PR TITLE
Do not clean non-existent directories

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -33,7 +33,7 @@ $(STATLIB):
 	  fi
 
 clean_intermediate:
-	rm -Rf $(STATLIB)
+	rm -f $(STATLIB)
 
 clean:
 	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target

--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -33,9 +33,9 @@ $(STATLIB):
 	  fi
 
 clean_intermediate:
-	rm -Rf $(STATLIB) ./rust/.cargo
+	rm -Rf $(STATLIB)
 
 clean:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target
 
 .PHONY: all clean_intermediate clean

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -32,7 +32,7 @@ $(STATLIB):
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 clean_intermediate:
-	rm -Rf $(STATLIB)
+	rm -f $(STATLIB)
 
 clean:
 	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -32,9 +32,9 @@ $(STATLIB):
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 clean_intermediate:
-	rm -Rf $(STATLIB) ./rust/.cargo
+	rm -Rf $(STATLIB)
 
 clean:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target
 
 .PHONY: all clean_intermediate clean

--- a/savvy-bindgen/src/gen/templates/Makevars.in
+++ b/savvy-bindgen/src/gen/templates/Makevars.in
@@ -33,7 +33,7 @@ $(STATLIB):
 	  fi
 
 clean_intermediate:
-	rm -Rf $(STATLIB)
+	rm -f $(STATLIB)
 
 clean:
 	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target

--- a/savvy-bindgen/src/gen/templates/Makevars.in
+++ b/savvy-bindgen/src/gen/templates/Makevars.in
@@ -33,9 +33,9 @@ $(STATLIB):
 	  fi
 
 clean_intermediate:
-	rm -Rf $(STATLIB) ./rust/.cargo
+	rm -Rf $(STATLIB)
 
 clean:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target
 
 .PHONY: all clean_intermediate clean

--- a/savvy-bindgen/src/gen/templates/Makevars.win.in
+++ b/savvy-bindgen/src/gen/templates/Makevars.win.in
@@ -32,7 +32,7 @@ $(STATLIB):
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 clean_intermediate:
-	rm -Rf $(STATLIB)
+	rm -f $(STATLIB)
 
 clean:
 	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target

--- a/savvy-bindgen/src/gen/templates/Makevars.win.in
+++ b/savvy-bindgen/src/gen/templates/Makevars.win.in
@@ -32,9 +32,9 @@ $(STATLIB):
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 clean_intermediate:
-	rm -Rf $(STATLIB) ./rust/.cargo
+	rm -Rf $(STATLIB)
 
 clean:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target
 
 .PHONY: all clean_intermediate clean


### PR DESCRIPTION
A follow up of https://github.com/yutannihilation/savvy/pull/357

`./rust/.cargo` and `./rust/vendor` are what are used when vendoring. This is not the case.