### PR TITLE
Release continous token by R_ReleaseObject()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 <!-- next-header -->
+
 ## [Unreleased] (ReleaseDate)
 
+- Fix memory leak related to `R_UnwindProtect()` (#368).
 
 ## [v0.8.9] (2025-04-12)
 
@@ -883,8 +885,8 @@ update`
 - `#[savvy]` now accepts `savvy::Sexp` as input.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/yutannihilation/savvy/compare/v0.8.9...HEAD
 
+[Unreleased]: https://github.com/yutannihilation/savvy/compare/v0.8.9...HEAD
 [v0.8.9]: https://github.com/yutannihilation/savvy/compare/v0.8.8...v0.8.9
 [v0.8.8]: https://github.com/yutannihilation/savvy/compare/v0.8.7...v0.8.8
 [v0.8.7]: https://github.com/yutannihilation/savvy/compare/v0.8.6...v0.8.7

--- a/src/unwind_protect_wrapper.c
+++ b/src/unwind_protect_wrapper.c
@@ -32,5 +32,10 @@ SEXP unwind_protect_impl(SEXP (*fun)(void *data), void *data) {
     // https://github.com/r-lib/cpp11/blob/4c840c03c8d62496cdab52e0c2c0d1857925debe/inst/include/cpp11/protect.hpp#L130-L133)
     SETCAR(token, R_NilValue);
 
+    // A token needs to be released. But, it seems cpp11 doesn't explicitly do
+    // this, yet has no memory leak. I still don't understand the difference, 
+    // but anyway it seems this is needed in savvy's case.
+    R_ReleaseObject(token);
+
     return res;
 }


### PR DESCRIPTION
Close #368

When I ported the code in cpp11 to savvy, I couldn't understand why cpp11 doesn't cause memory leak without calling `R_ReleaseObject()`. Maybe is this a difference between C++ and Rust about stack unwinding...?

https://github.com/r-lib/cpp11/blob/05c888b0c6f49e7b252b79b028e4719e6d5b299d/inst/include/cpp11/protect.hpp#L42

Anyway, it seems savvy needs this to prevent memory leak.