### PR TITLE
Use PROTECT() on continuous token

### DIFF
--- a/src/unwind_protect_wrapper.c
+++ b/src/unwind_protect_wrapper.c
@@ -11,7 +11,7 @@ void not_so_long_jump(void *jmpbuf, Rboolean jump) {
 
 SEXP unwind_protect_impl(SEXP (*fun)(void *data), void *data) {
     SEXP token = R_MakeUnwindCont();
-    R_PreserveObject(token);
+    PROTECT(token);
 
     jmp_buf jmpbuf;
     if (setjmp(jmpbuf)) {
@@ -21,21 +21,6 @@ SEXP unwind_protect_impl(SEXP (*fun)(void *data), void *data) {
 
     SEXP res = R_UnwindProtect(fun, data, not_so_long_jump, &jmpbuf, token);
 
-    // Comments on cpp11's code:
-    //
-    // R_UnwindProtect adds the result to the CAR of the continuation token,
-    // which implicitly protects the result. However if there is no error and
-    // R_UwindProtect does a normal exit the memory shouldn't be protected, so
-    // we unset it here before returning the value ourselves.
-    //
-    // (ref:
-    // https://github.com/r-lib/cpp11/blob/4c840c03c8d62496cdab52e0c2c0d1857925debe/inst/include/cpp11/protect.hpp#L130-L133)
-    SETCAR(token, R_NilValue);
-
-    // A token needs to be released. But, it seems cpp11 doesn't explicitly do
-    // this, yet has no memory leak. I still don't understand the difference, 
-    // but anyway it seems this is needed in savvy's case.
-    R_ReleaseObject(token);
-
+    UNPROTECT(1);
     return res;
 }


### PR DESCRIPTION
cf. https://bsky.app/profile/gaborcsardi.org/post/3lmznrhd3uc22

Fix #368

I was believing cpp11 uses `R_PreserveObject()` because `PROTECT()` doesn't work. But, it seems it does work.

I think `PROTECT()` is best if it works, because it automatically gets stack-unwound when longjmp. I don't fully understand the C/C++ things, but I think this is what is supposed to be.

Also, this pull request removes `SETCAR(token, R_NilValue)`. While cpp11 argues this is necessary to really release the continuous token, it seems the token gets GC-ed without doing it (It seems `CAR` of the continuous token is a length-1 of empty character vector). It might have been necessary in some older version of R? I don't know the details.