### PR TITLE
Reject unsupported return types

### DIFF
--- a/savvy-bindgen/src/ir/savvy_fn.rs
+++ b/savvy-bindgen/src/ir/savvy_fn.rs
@@ -625,6 +625,15 @@ fn get_savvy_return_type(
                                     }
                                 }
 
+                                // catch common mistakes
+                                wrong_ty @ ("String" | "i32" | "usize" | "f64" | "bool") => {
+                                    let msg = format!(
+"Return type mmust be either (), savvy::Sexp, or a user-defined type.
+You can use .try_into() to convert {wrong_ty} to savvy::Sexp."
+                                    );
+                                    return Err(syn::Error::new_spanned(type_path, msg));
+                                }
+
                                 // if it's the actual type, use it as it is.
                                 _ => {
                                     return Ok(SavvyFnReturnType::UserDefinedStruct(

--- a/savvy-macro/tests/cases/simple_cases.rs
+++ b/savvy-macro/tests/cases/simple_cases.rs
@@ -49,6 +49,33 @@ fn wrong_type_option_owned_int(x: Option<OwnedIntegerSexp>) -> savvy::Result<()>
     Ok(())
 }
 
+// wrong return type
+
+#[savvy]
+fn wrong_return_type1() -> savvy::Result<String> {
+    Ok(String::new())
+}
+
+#[savvy]
+fn wrong_return_type2() -> savvy::Result<i32> {
+    Ok(0)
+}
+
+#[savvy]
+fn wrong_return_type3() -> savvy::Result<usize> {
+    Ok(0)
+}
+
+#[savvy]
+fn wrong_return_type4() -> savvy::Result<bool> {
+    Ok(false)
+}
+
+#[savvy]
+fn wrong_return_type5() -> savvy::Result<f64> {
+    Ok(0.0)
+}
+
 // lifetime is not supported
 #[savvy]
 struct Foo<'a>(External::Bar<'a>);

--- a/savvy-macro/tests/cases/simple_cases.stderr
+++ b/savvy-macro/tests/cases/simple_cases.stderr
@@ -60,38 +60,73 @@ error: `Owned-` types are not allowed here. Did you mean `IntegerSexp`?
 48 | fn wrong_type_option_owned_int(x: Option<OwnedIntegerSexp>) -> savvy::Result<()> {
    |                                          ^^^^^^^^^^^^^^^^
 
-error: #[savvy] macro doesn't support lifetime
-  --> tests/cases/simple_cases.rs:54:12
+error: Return type mmust be either (), savvy::Sexp, or a user-defined type.
+       You can use .try_into() to convert String to savvy::Sexp.
+  --> tests/cases/simple_cases.rs:55:42
    |
-54 | struct Foo<'a>(External::Bar<'a>);
+55 | fn wrong_return_type1() -> savvy::Result<String> {
+   |                                          ^^^^^^
+
+error: Return type mmust be either (), savvy::Sexp, or a user-defined type.
+       You can use .try_into() to convert i32 to savvy::Sexp.
+  --> tests/cases/simple_cases.rs:60:42
+   |
+60 | fn wrong_return_type2() -> savvy::Result<i32> {
+   |                                          ^^^
+
+error: Return type mmust be either (), savvy::Sexp, or a user-defined type.
+       You can use .try_into() to convert usize to savvy::Sexp.
+  --> tests/cases/simple_cases.rs:65:42
+   |
+65 | fn wrong_return_type3() -> savvy::Result<usize> {
+   |                                          ^^^^^
+
+error: Return type mmust be either (), savvy::Sexp, or a user-defined type.
+       You can use .try_into() to convert bool to savvy::Sexp.
+  --> tests/cases/simple_cases.rs:70:42
+   |
+70 | fn wrong_return_type4() -> savvy::Result<bool> {
+   |                                          ^^^^
+
+error: Return type mmust be either (), savvy::Sexp, or a user-defined type.
+       You can use .try_into() to convert f64 to savvy::Sexp.
+  --> tests/cases/simple_cases.rs:75:42
+   |
+75 | fn wrong_return_type5() -> savvy::Result<f64> {
+   |                                          ^^^
+
+error: #[savvy] macro doesn't support lifetime
+  --> tests/cases/simple_cases.rs:81:12
+   |
+81 | struct Foo<'a>(External::Bar<'a>);
    |            ^^
 
 error: savvy only supports a fieldless enum
-  --> tests/cases/simple_cases.rs:59:6
+  --> tests/cases/simple_cases.rs:86:6
    |
-59 |     A(i32),
+86 |     A(i32),
    |      ^^^^^
 
 error: savvy doesn't support an enum with discreminant
-  --> tests/cases/simple_cases.rs:67:9
+  --> tests/cases/simple_cases.rs:94:9
    |
-67 |     B = 100,
+94 |     B = 100,
    |         ^^^
 
 error: DllInfo must be `*mut DllInfo`
-  --> tests/cases/simple_cases.rs:71:23
+  --> tests/cases/simple_cases.rs:98:23
    |
-71 | fn init_wrong_type(x: DllInfo) -> savvy::Result<()> {
+98 | fn init_wrong_type(x: DllInfo) -> savvy::Result<()> {
    |                       ^^^^^^^
 
 error: DllInfo must be `*mut DllInfo`
-  --> tests/cases/simple_cases.rs:76:24
-   |
-76 | fn init_wrong_type2(x: *const DllInfo) -> savvy::Result<()> {
-   |                        ^^^^^^^^^^^^^^
+   --> tests/cases/simple_cases.rs:103:24
+    |
+103 | fn init_wrong_type2(x: *const DllInfo) -> savvy::Result<()> {
+    |                        ^^^^^^^^^^^^^^
 
 error: #[savvy_init] can be used only on a function that takes `*mut DllInfo`
-  --> tests/cases/simple_cases.rs:81:41
-   |
-81 | fn init_wrong_type3(x: *mut DllInfo, y: i32) -> savvy::Result<()> {
-   |                                         ^^^
+   --> tests/cases/simple_cases.rs:108:41
+    |
+108 | fn init_wrong_type3(x: *mut DllInfo, y: i32) -> savvy::Result<()> {
+    |                                         ^^^


### PR DESCRIPTION
Close #382 

Now it doesn't compile if the return type is `savvy::Result<String>` etc.

```
   error: Return type mmust be either (), savvy::Sexp, or a user-defined type.
          You can use .try_into() to convert String to savvy::Sexp.
     --> src/lib.rs:11:39
      |
   11 |   fn stringme(&self) -> savvy::Result<String> {
      |                                       ^^^^^^
   
   error: could not compile `savvytest` (lib) due to 1 previous error
   make: *** [/Users/yutani/repo/savvytest/src/rust/target//debug/libsavvytest.a] Error 101
   ERROR: compilation failed for package ‘savvytest’
```