### PR TITLE
Address `MISMATCHED_LIFETIME_SYNTAXES` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
-- Unsupported return types like `savvy::Result<String>` now fail with a better compile error message (#382).
+- Unsupported return types like `savvy::Result<String>` now fail with a better
+  compile error message (#382).
+- The iterators returned by `.iter()` etc. are now properly annotated with
+  lifetimes. This should not break any existing code, but please report if
+  you find any issues.
 
 ## [v0.8.11] (2025-06-25)
 

--- a/savvy-bindgen/src/gen/c.rs
+++ b/savvy-bindgen/src/gen/c.rs
@@ -105,7 +105,7 @@ pub fn generate_c_header_file(result: &MergedResult) -> String {
                 .collect::<Vec<String>>()
                 .join("\n");
 
-            format!("\n// methods and associated functions for {}\n{}", ty, fns)
+            format!("\n// methods and associated functions for {ty}\n{fns}")
         })
         .collect::<Vec<String>>()
         .join("\n");

--- a/savvy-bindgen/src/gen/r.rs
+++ b/savvy-bindgen/src/gen/r.rs
@@ -57,7 +57,7 @@ impl SavvyFn {
                 if fn_name.as_str() == "new" {
                     ty_name
                 } else {
-                    format!("{}_{}", ty, fn_name)
+                    format!("{ty}_{fn_name}")
                 }
             }
             None => fn_name,
@@ -240,7 +240,7 @@ fn generate_r_impl_for_impl(
         .collect::<Vec<String>>()
         .join("\n");
 
-    let wrap_fn_name = format!(".savvy_wrap_{}", class_r);
+    let wrap_fn_name = format!(".savvy_wrap_{class_r}");
 
     let wrap_fn = format!(
         r#"`{wrap_fn_name}` <- function(ptr) {{

--- a/savvy-bindgen/src/parse_file.rs
+++ b/savvy-bindgen/src/parse_file.rs
@@ -122,7 +122,7 @@ impl ParsedResult {
                     syn::Type::Path(p) => p.path.segments.last().unwrap().ident.to_string(),
                     _ => "(unknown)".to_string(),
                 };
-                let label = format!("impl {}", self_ty);
+                let label = format!("impl {self_ty}");
 
                 item_impl
                     .items
@@ -200,7 +200,7 @@ impl ParsedResult {
                     Some(i) => i.to_string(),
                     None => "unknown".to_string(),
                 };
-                let label = format!("macro {}", ident);
+                let label = format!("macro {ident}");
 
                 self.tests.append(&mut parse_doctests(
                     &extract_docs(&item_macro.attrs),
@@ -253,10 +253,7 @@ fn parse_doctests<T: AsRef<str>>(lines: &[T], label: &str, location: &str) -> Ve
                     "ignore" | "no_run" | "text" => true,
                     "" => false,
                     _ => {
-                        eprintln!(
-                            "[WARN] Ignoring unsupported code block attribute: {}",
-                            code_attr
-                        );
+                        eprintln!("[WARN] Ignoring unsupported code block attribute: {code_attr}");
                         true
                     }
                 }

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -57,7 +57,7 @@ impl IntegerSexp {
     /// most efficient. However, it seems Rust's slice implementation is very
     /// fast, so probably being efficient for ALTREP is not worth giving up the
     /// benefit.
-    pub fn iter(&self) -> std::slice::Iter<i32> {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, i32> {
         self.as_slice().iter()
     }
 
@@ -119,7 +119,7 @@ impl OwnedIntegerSexp {
     }
 
     /// Returns an iterator over the underlying data of the SEXP.
-    pub fn iter(&self) -> std::slice::Iter<i32> {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, i32> {
         self.as_slice().iter()
     }
 
@@ -134,7 +134,7 @@ impl OwnedIntegerSexp {
     /// int_sexp.iter_mut().for_each(|x| *x = *x * 2);
     /// assert_eq!(int_sexp.as_slice(), &[2, 4, 6]);
     /// ```
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<i32> {
+    pub fn iter_mut<'a>(&'a mut self) -> std::slice::IterMut<'a, i32> {
         self.as_mut_slice().iter_mut()
     }
 

--- a/src/sexp/list.rs
+++ b/src/sexp/list.rs
@@ -53,7 +53,7 @@ impl ListSexp {
         }
     }
 
-    pub fn values_iter(&self) -> ListSexpValueIter {
+    pub fn values_iter<'a>(&'a self) -> ListSexpValueIter<'a> {
         ListSexpValueIter {
             sexp: self,
             i: 0,
@@ -78,7 +78,7 @@ impl ListSexp {
         crate::Sexp(self.inner()).get_class()
     }
 
-    pub fn iter(&self) -> ListSexpIter {
+    pub fn iter<'a>(&'a self) -> ListSexpIter<'a> {
         let names = self.names_iter();
         let values = self.values_iter();
 
@@ -123,7 +123,7 @@ impl OwnedListSexp {
         unsafe { self.values.get_by_index_unchecked(i) }
     }
 
-    pub fn values_iter(&self) -> ListSexpValueIter {
+    pub fn values_iter<'a>(&'a self) -> ListSexpValueIter<'a> {
         self.values.values_iter()
     }
 
@@ -131,7 +131,7 @@ impl OwnedListSexp {
         self.values.names_iter()
     }
 
-    pub fn iter(&self) -> ListSexpIter {
+    pub fn iter<'a>(&'a self) -> ListSexpIter<'a> {
         self.values.iter()
     }
 

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -52,7 +52,7 @@ impl LogicalSexp {
     /// assert_eq!(iter.next(), Some(true));
     /// assert_eq!(iter.collect::<Vec<bool>>(), vec![true, false]);
     /// ```
-    pub fn iter(&self) -> LogicalSexpIter {
+    pub fn iter<'a>(&'a self) -> LogicalSexpIter<'a> {
         LogicalSexpIter {
             iter_raw: self.as_slice_raw().iter(),
         }
@@ -102,7 +102,7 @@ impl OwnedLogicalSexp {
     /// assert_eq!(iter.next(), Some(true));
     /// assert_eq!(iter.collect::<Vec<bool>>(), vec![true, false]);
     /// ```
-    pub fn iter(&self) -> LogicalSexpIter {
+    pub fn iter<'a>(&'a self) -> LogicalSexpIter<'a> {
         LogicalSexpIter {
             iter_raw: self.as_slice_raw().iter(),
         }

--- a/src/sexp/numeric.rs
+++ b/src/sexp/numeric.rs
@@ -245,7 +245,7 @@ impl NumericSexp {
     /// assert!(e1.is_some());
     /// assert!(e1.unwrap().is_na());
     /// ```
-    pub fn iter_i32(&self) -> NumericIteratorI32 {
+    pub fn iter_i32<'a>(&'a self) -> NumericIteratorI32<'a> {
         match &self.0 {
             PrivateNumericSexp::Integer { orig, .. } => NumericIteratorI32 {
                 sexp: self,
@@ -294,7 +294,7 @@ impl NumericSexp {
     /// assert!(e2.is_some());
     /// assert!(e2.unwrap().is_err());
     /// ```
-    pub fn iter_f64(&self) -> NumericIteratorF64 {
+    pub fn iter_f64<'a>(&'a self) -> NumericIteratorF64<'a> {
         match &self.0 {
             PrivateNumericSexp::Real { orig, .. } => NumericIteratorF64 {
                 sexp: self,
@@ -315,7 +315,7 @@ impl NumericSexp {
     }
 
     /// Returns an iterator over the underlying data of the SEXP.
-    pub fn iter_usize(&self) -> NumericIteratorUsize {
+    pub fn iter_usize<'a>(&'a self) -> NumericIteratorUsize<'a> {
         NumericIteratorUsize {
             sexp: self,
             i: 0,

--- a/src/sexp/raw.rs
+++ b/src/sexp/raw.rs
@@ -56,7 +56,7 @@ impl RawSexp {
     /// most efficient. However, it seems Rust's slice implementation is very
     /// fast, so probably being efficient for ALTREP is not worth giving up the
     /// benefit.
-    pub fn iter(&self) -> std::slice::Iter<u8> {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, u8> {
         self.as_slice().iter()
     }
 
@@ -118,7 +118,7 @@ impl OwnedRawSexp {
     }
 
     /// Returns an iterator over the underlying data of the SEXP.
-    pub fn iter(&self) -> std::slice::Iter<u8> {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, u8> {
         self.as_slice().iter()
     }
 
@@ -133,7 +133,7 @@ impl OwnedRawSexp {
     /// raw_sexp.iter_mut().for_each(|x| *x = *x * 2);
     /// assert_eq!(raw_sexp.as_slice(), &[2, 4, 6]);
     /// ```
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<u8> {
+    pub fn iter_mut<'a>(&'a mut self) -> std::slice::IterMut<'a, u8> {
         self.as_mut_slice().iter_mut()
     }
 

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -57,7 +57,7 @@ impl RealSexp {
     /// most efficient. However, it seems Rust's slice implementation is very
     /// fast, so probably being efficient for ALTREP is not worth giving up the
     /// benefit.
-    pub fn iter(&self) -> std::slice::Iter<f64> {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, f64> {
         self.as_slice().iter()
     }
 
@@ -119,7 +119,7 @@ impl OwnedRealSexp {
     }
 
     /// Returns an iterator over the underlying data of the SEXP.
-    pub fn iter(&self) -> std::slice::Iter<f64> {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, f64> {
         self.as_slice().iter()
     }
 
@@ -134,7 +134,7 @@ impl OwnedRealSexp {
     /// real_sexp.iter_mut().for_each(|x| *x = *x * 2.0);
     /// assert_eq!(real_sexp.as_slice(), &[2.0, 4.0, 6.0]);
     /// ```
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<f64> {
+    pub fn iter_mut<'a>(&'a mut self) -> std::slice::IterMut<'a, f64> {
         self.as_mut_slice().iter_mut()
     }
 

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -31,7 +31,7 @@ impl StringSexp {
     /// assert_eq!(iter.next(), Some("a"));
     /// assert_eq!(iter.collect::<Vec<&str>>(), vec!["b", "c"]);
     /// ```
-    pub fn iter(&self) -> StringSexpIter {
+    pub fn iter<'a>(&'a self) -> StringSexpIter<'a> {
         StringSexpIter {
             sexp: &self.0,
             i: 0,
@@ -72,7 +72,7 @@ impl OwnedStringSexp {
     /// assert_eq!(iter.next(), Some("a"));
     /// assert_eq!(iter.collect::<Vec<&str>>(), vec!["b", "c"]);
     /// ```
-    pub fn iter(&self) -> StringSexpIter {
+    pub fn iter<'a>(&'a self) -> StringSexpIter<'a> {
         StringSexpIter {
             sexp: &self.inner,
             i: 0,


### PR DESCRIPTION
Address this lint: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html

Although the warning suggests to use an anonymous lifetime, the intention was that the iterator should have the same lifetime as `&self`. So, this pull request explicitly annotated it.

```
warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/sexp/logical.rs:55:17
   |
55 |     pub fn iter(&self) -> LogicalSexpIter {
   |                 ^^^^^     --------------- the lifetime gets resolved as `'_`
   |                 |
   |                 this lifetime flows to the output
   |
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
55 |     pub fn iter(&self) -> LogicalSexpIter<'_> {
   |                                          ++++
```

Also, inlined some variables used for `format!()`.