### PR TITLE
Add is_scalar_na()

### DIFF
--- a/src/sexp/mod.rs
+++ b/src/sexp/mod.rs
@@ -44,6 +44,11 @@ impl Sexp {
         unsafe { self.0 == R_NilValue }
     }
 
+    /// Return true if the SEXP is a length-1 of vector containing NA.
+    pub fn is_scalar_na(&self) -> bool {
+        unsafe { na::is_scalar_na(self.0) }
+    }
+
     /// Returns `true` if the SEXP is an integer vector.
     pub fn is_integer(&self) -> bool {
         unsafe { Rf_isInteger(self.0) == Rboolean_TRUE }

--- a/src/sexp/na.rs
+++ b/src/sexp/na.rs
@@ -63,3 +63,22 @@ impl NotAvailableValue for &str {
         })
     }
 }
+
+/// Return true if the SEXP is a length-1 of vector containing NA.
+pub(crate) unsafe fn is_scalar_na(x: savvy_ffi::SEXP) -> bool {
+    if unsafe { savvy_ffi::Rf_xlength(x) } != 1 {
+        return false;
+    }
+
+    let ty = unsafe { savvy_ffi::TYPEOF(x) };
+    match ty {
+        savvy_ffi::INTSXP => unsafe { savvy_ffi::INTEGER_ELT(x, 0) }.is_na(),
+        savvy_ffi::REALSXP => unsafe { savvy_ffi::REAL_ELT(x, 0) }.is_na(),
+        #[cfg(feature = "complex")]
+        savvy_ffi::CPLXSXP => unsafe { savvy_ffi::COMPLEX_ELT(x, 0) }.is_na(),
+        savvy_ffi::LGLSXP => unsafe { savvy_ffi::LOGICAL_ELT(x, 0) }.is_na(),
+        savvy_ffi::RAWSXP => false, // raw doesn't have NA
+        savvy_ffi::STRSXP => unsafe { savvy_ffi::STRING_ELT(x, 0) == savvy_ffi::R_NaString },
+        _ => false,
+    }
+}


### PR DESCRIPTION
```rs
#[savvy]
fn foo(x: Sexp) -> savvy::Result<Sexp> {
    if x.is_scalar_na() {
        // treat NA differently
    }
    ...
}
```