### PR TITLE
Use `std::ptr::null_mut()` instead of `R_MissingArg`

### DIFF
--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -224,7 +224,6 @@ extern "C" {
     pub fn R_existsVarInFrame(arg1: SEXP, arg2: SEXP) -> Rboolean;
 
     pub static mut R_GlobalEnv: SEXP;
-    pub static mut R_MissingArg: SEXP;
 }
 
 // Parse

--- a/src/sexp/environment.rs
+++ b/src/sexp/environment.rs
@@ -4,9 +4,9 @@ use savvy_ffi::{R_GlobalEnv, R_NilValue, Rboolean_TRUE, SEXP};
 
 // Note: Since `unwind_protect()` can only return an SEXP, we need some sentinel
 // value to indicate either success or failure. Any SEXP can be used here as
-// long as it's (1) not a user-facing value, (2) not a non-API, and (3) not a
-// value that Rf_eval() possibly returns. A null pointer is invalid as an SEXP,
-// but that's why it fits for this usage.
+// long as it's (1) not a value that Rf_eval() possibly returns, and (2) not a
+// non-API. A null pointer is invalid as an SEXP, but that's why it fits for
+// this usage.
 const THE_SENTINEL_VALUE: SEXP = std::ptr::null_mut() as SEXP;
 
 use crate::{savvy_err, Sexp};

--- a/src/sexp/environment.rs
+++ b/src/sexp/environment.rs
@@ -2,11 +2,12 @@ use std::ffi::CString;
 
 use savvy_ffi::{R_GlobalEnv, R_NilValue, Rboolean_TRUE, SEXP};
 
-// Note: This is an ugly workaround; since `unwind_protect()` can only return an
-// SEXP, we need some sentinel value to indicate either success or failure. Any
-// SEXP can be used here as long as it's (1) not a user-facing value and (2) not
-// a non-API. I've been using R_UnboundValue, but it's non-API since R 4.6.
-use savvy_ffi::R_MissingArg as THE_SENTINEL_VALUE;
+// Note: Since `unwind_protect()` can only return an SEXP, we need some sentinel
+// value to indicate either success or failure. Any SEXP can be used here as
+// long as it's (1) not a user-facing value, (2) not a non-API, and (3) not a
+// value that Rf_eval() possibly returns. A null pointer is invalid as an SEXP,
+// but that's why it fits for this usage.
+const THE_SENTINEL_VALUE: SEXP = std::ptr::null_mut() as SEXP;
 
 use crate::{savvy_err, Sexp};
 
@@ -55,7 +56,7 @@ impl EnvironmentSexp {
             })?
         };
 
-        if sexp == unsafe { THE_SENTINEL_VALUE } {
+        if sexp == THE_SENTINEL_VALUE {
             Ok(None)
         } else {
             Ok(Some(Sexp(sexp)))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -160,7 +160,6 @@ fn show() -> Result<(), DynError> {
         .allowlist_var("R_GlobalEnv")
         .allowlist_function("R_existsVarInFrame")
         .allowlist_function("Rf_defineVar")
-        .allowlist_var("R_MissingArg")
         // parse
         .allowlist_function("R_ParseEvalString")
         .allowlist_function("R_compute_identical")


### PR DESCRIPTION
Implement https://github.com/yutannihilation/savvy/pull/430#discussion_r3053253820

Since `unwind_protect()` can only return an SEXP, we need some sentinel value to indicate either success or failure. Any SEXP can be used here as long as it's

1. not a value that `Rf_eval()` possibly returns
2. not a non-API

A null pointer is invalid as an SEXP, but that's why it nicely satisfies these two points. Thanks @paleolimbot for the idea!