### PR TITLE
Ignore `-flto=*` on compiling `unwind_protect_wrapper.c`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### Minor improvements
+
+- Pass `-ffat-lto-objects` when compiling `unwind_protect_wrapper.c` (and `altrep_class.c` in `savvy-ffi`) on non-macOS platforms. Without this, R build environments that inject `-flto=N` via `CFLAGS` (e.g. the gcc-SAN builder) produce slim LTO objects whose symbols are missing from the archive index after Rust bundles them into the final staticlib, causing `undefined symbol` errors at package load.
+
 ## [v0.10.1] (2026-04-13)
 
 ### Minor improvements

--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -23,7 +23,7 @@ $(STATLIB):
 	# therefore is only used if cargo is absent from the user's PATH.
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	  export CC="$(CC)" && \
-	  export CFLAGS="$(CFLAGS)" && \
+	  export CFLAGS="$(CFLAGS) -flto=10" && \
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  @BEFORE_CARGO_BUILD@ \
 	  if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \

--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -23,7 +23,7 @@ $(STATLIB):
 	# therefore is only used if cargo is absent from the user's PATH.
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	  export CC="$(CC)" && \
-	  export CFLAGS="$(CFLAGS) -flto=10" && \
+	  export CFLAGS="$(CFLAGS)" && \
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  @BEFORE_CARGO_BUILD@ \
 	  if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \

--- a/build.rs
+++ b/build.rs
@@ -5,14 +5,25 @@ fn main() {
 
     // TODO: to pass the build of cargo-dist, this must be built without any errors.
     if let Ok(d) = r_include_dir {
+        // Strip any `-flto*` from CFLAGS before cc-rs reads it. R's gcc-SAN
+        // builder injects `-flto=N` via CFLAGS; if the wrapper is compiled as
+        // LTO bitcode, `unwind_protect_impl` is lost when Rust archives the
+        // native static lib into the final staticlib, producing an undefined
+        // symbol at package load time. Appending `-fno-lto` is not enough —
+        // cc-rs' flag order doesn't reliably place user flags after CFLAGS.
+        if let Ok(cflags) = std::env::var("CFLAGS") {
+            let cleaned: String = cflags
+                .split_whitespace()
+                .filter(|f| !f.starts_with("-flto"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            // SAFETY: build.rs is single-threaded when this runs.
+            unsafe { std::env::set_var("CFLAGS", cleaned); }
+        }
+
         cc::Build::new()
             .file("src/unwind_protect_wrapper.c")
             .include(Path::new(d.as_str()))
-            // Disable LTO for this TU. R's gcc-SAN builder injects `-flto=*`
-            // via CFLAGS, which breaks linking against the Rust staticlib.
-            // A trailing `-fno-lto` overrides it; `flag_if_supported` no-ops
-            // on compilers that don't recognize the flag (e.g. MSVC).
-            .flag_if_supported("-fno-lto")
             .compile("unwind_protect");
     } else {
         println!("cargo:warning=R_INCLUDE_DIR envvar should be provided.");

--- a/build.rs
+++ b/build.rs
@@ -5,25 +5,17 @@ fn main() {
 
     // TODO: to pass the build of cargo-dist, this must be built without any errors.
     if let Ok(d) = r_include_dir {
-        // Strip any `-flto*` from CFLAGS before cc-rs reads it. R's gcc-SAN
-        // builder injects `-flto=N` via CFLAGS; if the wrapper is compiled as
-        // LTO bitcode, `unwind_protect_impl` is lost when Rust archives the
-        // native static lib into the final staticlib, producing an undefined
-        // symbol at package load time. Appending `-fno-lto` is not enough —
-        // cc-rs' flag order doesn't reliably place user flags after CFLAGS.
-        if let Ok(cflags) = std::env::var("CFLAGS") {
-            let cleaned: String = cflags
-                .split_whitespace()
-                .filter(|f| !f.starts_with("-flto"))
-                .collect::<Vec<_>>()
-                .join(" ");
-            // SAFETY: build.rs is single-threaded when this runs.
-            unsafe { std::env::set_var("CFLAGS", cleaned); }
-        }
-
         cc::Build::new()
             .file("src/unwind_protect_wrapper.c")
             .include(Path::new(d.as_str()))
+            // When R's CFLAGS inject `-flto=N` (e.g. gcc-SAN builder), gcc emits
+            // slim LTO objects whose symbols don't land in the archive index
+            // after Rust `ar`s them into the final staticlib, causing
+            // `unwind_protect_impl` to go missing at package load. Fat LTO
+            // objects carry both bitcode and real ELF symbols, which keeps the
+            // archive index correct. `flag_if_supported` no-ops on compilers
+            // that don't recognize it (clang, MSVC).
+            .flag_if_supported("-ffat-lto-objects")
             .compile("unwind_protect");
     } else {
         println!("cargo:warning=R_INCLUDE_DIR envvar should be provided.");

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,11 @@ fn main() {
         cc::Build::new()
             .file("src/unwind_protect_wrapper.c")
             .include(Path::new(d.as_str()))
+            // Disable LTO for this TU. R's gcc-SAN builder injects `-flto=*`
+            // via CFLAGS, which breaks linking against the Rust staticlib.
+            // A trailing `-fno-lto` overrides it; `flag_if_supported` no-ops
+            // on compilers that don't recognize the flag (e.g. MSVC).
+            .flag_if_supported("-fno-lto")
             .compile("unwind_protect");
     } else {
         println!("cargo:warning=R_INCLUDE_DIR envvar should be provided.");

--- a/build.rs
+++ b/build.rs
@@ -2,21 +2,28 @@ use std::path::Path;
 
 fn main() {
     let r_include_dir = std::env::var("R_INCLUDE_DIR");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     // TODO: to pass the build of cargo-dist, this must be built without any errors.
     if let Ok(d) = r_include_dir {
-        cc::Build::new()
+        let mut build = cc::Build::new();
+        build
             .file("src/unwind_protect_wrapper.c")
-            .include(Path::new(d.as_str()))
-            // When R's CFLAGS inject `-flto=N` (e.g. gcc-SAN builder), gcc emits
-            // slim LTO objects whose symbols don't land in the archive index
-            // after Rust `ar`s them into the final staticlib, causing
-            // `unwind_protect_impl` to go missing at package load. Fat LTO
-            // objects carry both bitcode and real ELF symbols, which keeps the
-            // archive index correct. `flag_if_supported` no-ops on compilers
-            // that don't recognize it (clang, MSVC).
-            .flag_if_supported("-ffat-lto-objects")
-            .compile("unwind_protect");
+            .include(Path::new(d.as_str()));
+
+        // When R's CFLAGS inject `-flto=N` (e.g. gcc-SAN builder), gcc emits
+        // slim LTO objects whose symbols don't land in the archive index
+        // after Rust `ar`s them into the final staticlib, causing
+        // `unwind_protect_impl` to go missing at package load. Fat LTO
+        // objects carry both bitcode and real ELF symbols, which keeps the
+        // archive index correct. Skipped on macOS because clang doesn't
+        // recognize the flag (and cc-rs' `flag_if_supported` probe would
+        // emit a `flag_check.c` that trips a CRAN line-endings NOTE).
+        if target_os != "macos" {
+            build.flag("-ffat-lto-objects");
+        }
+
+        build.compile("unwind_protect");
     } else {
         println!("cargo:warning=R_INCLUDE_DIR envvar should be provided.");
     }

--- a/savvy-ffi/build.rs
+++ b/savvy-ffi/build.rs
@@ -8,6 +8,8 @@ fn main() {
         cc::Build::new()
             .file("src/backports/altrep_class.c")
             .include(Path::new(d.as_str()))
+            // See ../build.rs for why this matters under `-flto` in CFLAGS.
+            .flag_if_supported("-ffat-lto-objects")
             .compile("altrep_class");
     } else {
         println!("cargo:warning=R_INCLUDE_DIR envvar should be provided.");

--- a/savvy-ffi/build.rs
+++ b/savvy-ffi/build.rs
@@ -2,15 +2,21 @@ use std::path::Path;
 
 fn main() {
     let r_include_dir = std::env::var("R_INCLUDE_DIR");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     // TODO: to pass the build of cargo-dist, this must be built without any errors.
     if let Ok(d) = r_include_dir {
-        cc::Build::new()
+        let mut build = cc::Build::new();
+        build
             .file("src/backports/altrep_class.c")
-            .include(Path::new(d.as_str()))
-            // See ../build.rs for why this matters under `-flto` in CFLAGS.
-            .flag_if_supported("-ffat-lto-objects")
-            .compile("altrep_class");
+            .include(Path::new(d.as_str()));
+
+        // See ../build.rs for why this matters under `-flto` in CFLAGS.
+        if target_os != "macos" {
+            build.flag("-ffat-lto-objects");
+        }
+
+        build.compile("altrep_class");
     } else {
         println!("cargo:warning=R_INCLUDE_DIR envvar should be provided.");
     }


### PR DESCRIPTION
cf. https://github.com/yutannihilation/string2path/pull/210

We observed gcc-ASAN build failed because it adds `-flto=10`; since the latest Makevars.in passes CFLAGS to the cc crate, it blows away the symbol. We should not let it get optimized at this point.

```
** testing if installed package can be loaded from temporary location
Error: package or namespace load failed for ‘string2path’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/data/gannet/ripley/R/packages/tests-gcc-SAN/string2path.Rcheck/00LOCK-string2path/00new/string2path/libs/string2path.so':
  /data/gannet/ripley/R/packages/tests-gcc-SAN/string2path.Rcheck/00LOCK-string2path/00new/string2path/libs/string2path.so: undefined symbol: unwind_protect_impl
Error: loading failed
Execution halted
ERROR: loading failed
```