### PR TITLE
Fix clippy warnings

### DIFF
--- a/savvy-bindgen/src/ir/savvy_fn.rs
+++ b/savvy-bindgen/src/ir/savvy_fn.rs
@@ -613,10 +613,8 @@ fn get_savvy_return_type(
 
                 if let syn::GenericArgument::Type(ty) = &args.first().unwrap() {
                     match ty {
-                        syn::Type::Tuple(type_tuple) => {
-                            if type_tuple.elems.is_empty() {
-                                return Ok(SavvyFnReturnType::Unit(return_type.clone()));
-                            }
+                        syn::Type::Tuple(type_tuple) if type_tuple.elems.is_empty() => {
+                            return Ok(SavvyFnReturnType::Unit(return_type.clone()));
                         }
 
                         syn::Type::Path(type_path) => {

--- a/savvy-cli/src/main.rs
+++ b/savvy-cli/src/main.rs
@@ -375,12 +375,12 @@ fn update(path: &Path, rust_dir: &Option<PathBuf>) {
 
     write_file(
         &path.join(PATH_C_IMPL),
-        &generate_c_impl_file(&merged, &pkg_name),
+        &generate_c_impl_file(&merged, pkg_name),
     );
 
     write_file(
         &path.join(PATH_R_IMPL),
-        &generate_r_impl_file(&merged, &pkg_name),
+        &generate_r_impl_file(&merged, pkg_name),
     );
     tweak_r_buildignore(path);
 }


### PR DESCRIPTION
```
warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> savvy-cli\src\main.rs:378:40
    |
378 |         &generate_c_impl_file(&merged, &pkg_name),
    |                                        ^^^^^^^^^ help: change this to: `pkg_name`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> savvy-cli\src\main.rs:383:40
    |
383 |         &generate_r_impl_file(&merged, &pkg_name),
    |                                        ^^^^^^^^^ help: change this to: `pkg_name`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#needless_borrow

warning: `savvy-cli` (bin "savvy-cli") generated 2 warnings (run `cargo clippy --fix --bin "savvy-cli" -p savvy-cli -- ` to apply 2 suggestions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.38s
```