### PR TITLE
feat!: Use R_getVarEx(), require R >= 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@
 
 ### Breaking changes
 
-- savvy now requires R >= 4.5. `EnvironmentSexp::get()` now uses `R_getVarEx()`,
-  which is available since R 4.5, instead of `R_existsVarInFrame()` and
-  `Rf_eval()`. Accordingly, the backport of `VECTOR_PTR_RO()` for R < 4.5 is
-  removed. Building against an older R now fails with an explicit error.
+- savvy now requires R >= 4.5. Building against an older R now fails with an explicit error (#458).
 
 ### Minor improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### Breaking changes
+
+- savvy now requires R >= 4.5. `EnvironmentSexp::get()` now uses `R_getVarEx()`,
+  which is available since R 4.5, instead of `R_existsVarInFrame()` and
+  `Rf_eval()`. Accordingly, the backport of `VECTOR_PTR_RO()` for R < 4.5 is
+  removed. Building against an older R now fails with an explicit error.
+
 ### Minor improvements
 
 - Update the syn crate to v3 (#455).

--- a/R-package/tests/testthat/test-environment.R
+++ b/R-package/tests/testthat/test-environment.R
@@ -21,4 +21,13 @@ test_that("environment", {
   # global env
   .GlobalEnv$global_obj <- "ABC"
   expect_equal(get_var_in_env("global_obj"), "ABC")
+
+  # a promise is forced
+  e3 <- new.env(parent = emptyenv())
+  delayedAssign("d", "lazy", assign.env = e3)
+  expect_equal(get_var_in_env("d", e3), "lazy")
+
+  # an error while forcing a promise is propagated
+  delayedAssign("e", stop("boom"), assign.env = e3)
+  expect_error(get_var_in_env("e", e3), "boom")
 })

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ to_upper(c("a", "b", "c"))
 #> [1] "A" "B" "C"
 ```
 
+## Requirements
+
+- R \>= 4.5
+- Rust \>= 1.88
+
 ## Documents
 
 - [user guide](https://yutannihilation.github.io/savvy/guide/)

--- a/README.qmd
+++ b/README.qmd
@@ -72,6 +72,11 @@ to_upper(c("a", "b", "c"))
 
 [extendr]: https://extendr.github.io/
 
+## Requirements
+
+- R >= 4.5
+- Rust >= 1.88
+
 ## Documents
 
 - [user guide](https://yutannihilation.github.io/savvy/guide/)

--- a/savvy-ffi/src/backports/backports.c
+++ b/savvy-ffi/src/backports/backports.c
@@ -4,6 +4,13 @@
 #include <Rinternals.h>
 #include <R_ext/Altrep.h>
 
+// savvy requires R >= 4.5 (e.g. for R_getVarEx()). Without this check, building
+// against an older R succeeds and the package fails at load time with an
+// undefined symbol error, which is much harder to understand.
+#if R_VERSION < R_Version(4, 5, 0)
+#error "savvy requires R 4.5.0 or later"
+#endif
+
 #if R_VERSION < R_Version(4, 6, 0)
 SEXP R_altrep_class_name(SEXP x)
 {
@@ -12,12 +19,5 @@ SEXP R_altrep_class_name(SEXP x)
 SEXP R_altrep_class_package(SEXP x)
 {
     return ALTREP(x) ? CADR(ATTRIB(ALTREP_CLASS(x))) : R_NilValue;
-}
-#endif
-
-#if R_VERSION < R_Version(4, 5, 0)
-const void *VECTOR_PTR_RO(SEXP x)
-{
-    return DATAPTR_RO(x);
 }
 #endif

--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -222,6 +222,7 @@ unsafe extern "C" {
     pub fn Rf_eval(arg1: SEXP, arg2: SEXP) -> SEXP;
     pub fn Rf_defineVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn R_existsVarInFrame(arg1: SEXP, arg2: SEXP) -> Rboolean;
+    pub fn R_getVarEx(arg1: SEXP, arg2: SEXP, arg3: Rboolean, arg4: SEXP) -> SEXP;
 
     pub static mut R_GlobalEnv: SEXP;
 }

--- a/src/sexp/environment.rs
+++ b/src/sexp/environment.rs
@@ -1,12 +1,15 @@
 use std::ffi::CString;
 
-use savvy_ffi::{R_GlobalEnv, R_NilValue, Rboolean_TRUE, SEXP};
+use savvy_ffi::{R_GlobalEnv, R_NilValue, Rboolean_FALSE, Rboolean_TRUE, SEXP};
 
 // Note: Since `unwind_protect()` can only return an SEXP, we need some sentinel
 // value to indicate either success or failure. Any SEXP can be used here as
-// long as it's (1) not a value that Rf_eval() possibly returns, and (2) not a
-// non-API. A null pointer is invalid as an SEXP, but that's why it fits for
-// this usage.
+// long as it's (1) not a value that R possibly returns, and (2) not a non-API.
+// A null pointer is invalid as an SEXP, but that's why it fits for this usage.
+//
+// This is also used as the `ifnotfound` argument of R_getVarEx(), which returns
+// it as is without touching it (this is the same assumption as
+// unwind_protect_wrapper.c, which passes this value through R_UnwindProtect()).
 const THE_SENTINEL_VALUE: SEXP = std::ptr::null_mut() as SEXP;
 
 use crate::{Sexp, savvy_err};
@@ -46,13 +49,8 @@ impl EnvironmentSexp {
         // need protection.
         let sexp = unsafe {
             crate::unwind_protect(|| {
-                if savvy_ffi::R_existsVarInFrame(self.0, sym) == Rboolean_TRUE {
-                    // TODO: replace this with R_getVar() when savvy drop supports on R <4.5
-                    savvy_ffi::Rf_eval(sym, self.0)
-                } else {
-                    // In this case, THE_SENTINEL_VALUE indicates a failure
-                    THE_SENTINEL_VALUE
-                }
+                // THE_SENTINEL_VALUE is returned when the variable is not found
+                savvy_ffi::R_getVarEx(sym, self.0, Rboolean_FALSE, THE_SENTINEL_VALUE)
             })?
         };
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -159,6 +159,7 @@ fn show() -> Result<(), DynError> {
         .allowlist_function("Rf_eval")
         .allowlist_var("R_GlobalEnv")
         .allowlist_function("R_existsVarInFrame")
+        .allowlist_function("R_getVarEx")
         .allowlist_function("Rf_defineVar")
         // parse
         .allowlist_function("R_ParseEvalString")


### PR DESCRIPTION
Close #440 

I was thinking if we can use backports, but I realized that it is considered to violate the license if we inline the R's source code, which is licensed under GPL. So, I gave up and decided to drop the support for R < 4.5.