### PR TITLE
feat!: Support Rust 1.81

### DIFF
--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@1.81.0
 
       - name: Build
         run: cargo build

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -13,7 +13,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@1.81.0
+      # Resolve dependencies with a modern cargo, preferring versions that
+      # respect the declared rust-version, before switching to the MSRV
+      # toolchain (whose cargo predates the MSRV-aware resolver).
+      - name: Generate lockfile
+        run: cargo generate-lockfile
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
+
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: "1.81.0"
 
       - name: Build
-        run: cargo build
+        run: cargo build --locked
+
+      # The features are not covered by the plain build above
+      - name: Build with features
+        run: cargo build --locked --features complex,altrep,logger,savvy-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Minor improvements
 
+- Lower the MSRV of the savvy crate to 1.81 by reverting to Rust 2021 edition.
+  The generated packages also use Rust 2021 edition now. Note that this doesn't
+  apply to savvy-cli, whose dependencies require a newer Rust; use the prebuilt
+  binaries if your toolchain is old.
 - Update the syn crate to v3 (#455).
 - `savvy-cli init` now generates configuration files complatible with [ARM64 Windows] (`aarch64-pc-windows-gnullvm` target). Note that this change is not automatically reflected by `savvy-cli update`, so please update these files manually: [`configure.win`] (#459).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,10 @@
 ### Breaking changes
 
 - savvy now requires R >= 4.5. Building against an older R now fails with an explicit error (#458).
+- Lower the MSRV of the savvy crate to 1.81 by reverting to Rust 2021 edition.
 
 ### Minor improvements
 
-- Lower the MSRV of the savvy crate to 1.81 by reverting to Rust 2021 edition.
-  The generated packages also use Rust 2021 edition now. Note that this doesn't
-  apply to savvy-cli, whose dependencies require a newer Rust; use the prebuilt
-  binaries if your toolchain is old.
 - Update the syn crate to v3 (#455).
 - `savvy-cli init` now generates configuration files complatible with [ARM64 Windows] (`aarch64-pc-windows-gnullvm` target). Note that this change is not automatically reflected by `savvy-cli update`, so please update these files manually: [`configure.win`] (#459).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 readme = "README.md"
 exclude = ["/book", "/R-package", "README.qmd"]
 
-rust-version = "1.81"
+rust-version.workspace = true
 
 [dependencies]
 savvy-ffi = { version = "0.10.2", path = "./savvy-ffi" }
@@ -68,6 +68,8 @@ resolver = "2"
 [workspace.package]
 version = "0.10.2"
 edition = "2021"
+# std::panic::PanicHookInfo, which savvy relies on, is introduced in 1.81
+rust-version = "1.81"
 authors = ["Hiroaki Yutani"]
 license = "MIT"
 repository = "https://github.com/yutannihilation/savvy/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 readme = "README.md"
 exclude = ["/book", "/R-package", "README.qmd"]
 
-rust-version = "1.88"
+rust-version = "1.81"
 
 [dependencies]
 savvy-ffi = { version = "0.10.2", path = "./savvy-ffi" }
@@ -67,7 +67,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.10.2"
-edition = "2024"
+edition = "2021"
 authors = ["Hiroaki Yutani"]
 license = "MIT"
 repository = "https://github.com/yutannihilation/savvy/"

--- a/R-package/src/rust/Cargo.toml
+++ b/R-package/src/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple-savvy"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/R-package/src/rust/src/convert_from_rust_types.rs
+++ b/R-package/src/rust/src/convert_from_rust_types.rs
@@ -100,48 +100,48 @@ fn sum_real(x: RealSexp) -> savvy::Result<savvy::Sexp> {
 
 #[savvy]
 fn rep_int_vec(x: i32) -> savvy::Result<savvy::Sexp> {
-    let result: Vec<i32> = std::iter::repeat_n(0, x as usize).collect();
+    let result: Vec<i32> = vec![0; x as usize];
     result.try_into()
 }
 
 #[savvy]
 fn rep_int_slice(x: i32) -> savvy::Result<savvy::Sexp> {
-    let result: Vec<i32> = std::iter::repeat_n(0, x as usize).collect();
+    let result: Vec<i32> = vec![0; x as usize];
     result.as_slice().try_into()
 }
 
 #[savvy]
 fn rep_real_vec(x: i32) -> savvy::Result<savvy::Sexp> {
-    let result: Vec<f64> = std::iter::repeat_n(0.0, x as usize).collect();
+    let result: Vec<f64> = vec![0.0; x as usize];
     result.try_into()
 }
 
 #[savvy]
 fn rep_real_slice(x: i32) -> savvy::Result<savvy::Sexp> {
-    let result: Vec<f64> = std::iter::repeat_n(0.0, x as usize).collect();
+    let result: Vec<f64> = vec![0.0; x as usize];
     result.as_slice().try_into()
 }
 
 #[savvy]
 fn rep_bool_vec(x: i32) -> savvy::Result<savvy::Sexp> {
-    let result: Vec<bool> = std::iter::repeat_n(true, x as usize).collect();
+    let result: Vec<bool> = vec![true; x as usize];
     result.try_into()
 }
 
 #[savvy]
 fn rep_bool_slice(x: i32) -> savvy::Result<savvy::Sexp> {
-    let result: Vec<bool> = std::iter::repeat_n(true, x as usize).collect();
+    let result: Vec<bool> = vec![true; x as usize];
     result.as_slice().try_into()
 }
 
 #[savvy]
 fn rep_str_vec(x: i32) -> savvy::Result<savvy::Sexp> {
-    let result: Vec<&str> = std::iter::repeat_n("foo", x as usize).collect();
+    let result: Vec<&str> = vec!["foo"; x as usize];
     result.try_into()
 }
 
 #[savvy]
 fn rep_str_slice(x: i32) -> savvy::Result<savvy::Sexp> {
-    let result: Vec<&str> = std::iter::repeat_n("foo", x as usize).collect();
+    let result: Vec<&str> = vec!["foo"; x as usize];
     result.as_slice().try_into()
 }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ to_upper(c("a", "b", "c"))
 ## Requirements
 
 - R \>= 4.5
-- Rust \>= 1.88
+- Rust \>= 1.81
 
 ## Documents
 

--- a/README.qmd
+++ b/README.qmd
@@ -75,7 +75,7 @@ to_upper(c("a", "b", "c"))
 ## Requirements
 
 - R >= 4.5
-- Rust >= 1.88
+- Rust >= 1.81
 
 ## Documents
 

--- a/savvy-bindgen/Cargo.toml
+++ b/savvy-bindgen/Cargo.toml
@@ -3,6 +3,7 @@ name = "savvy-bindgen"
 description = "Parse Rust functions, and generate C and R code"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/savvy-bindgen/src/codegen/r.rs
+++ b/savvy-bindgen/src/codegen/r.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use syn::Ident;
 use syn::ext::IdentExt;
+use syn::Ident;
 
 use crate::ir::SavvyMergedImpl;
 use crate::utils::add_indent;

--- a/savvy-bindgen/src/codegen/rust.rs
+++ b/savvy-bindgen/src/codegen/rust.rs
@@ -1,4 +1,4 @@
-use syn::{Token, parse_quote};
+use syn::{parse_quote, Token};
 
 use crate::ir::savvy_fn::{SavvyFnReturnType, UserDefinedStructReturnType};
 use crate::{SavvyFn, SavvyFnType};
@@ -175,7 +175,7 @@ impl SavvyFn {
                     parse_quote!(
                         #(#attrs)*
                         #[allow(clippy::missing_safety_doc)]
-                        #[unsafe(no_mangle)]
+                        #[no_mangle]
                         pub unsafe extern "C" fn #fn_name_ffi(self__: savvy::ffi::SEXP, #(#args_pat: #args_ty),* ) -> savvy::ffi::SEXP {
                             match #fn_name_inner(self__, #(#args_pat),*) {
                                 Ok(#ok_lhs) => #ok_rhs,
@@ -187,7 +187,7 @@ impl SavvyFn {
                     parse_quote!(
                         #(#attrs)*
                         #[allow(clippy::missing_safety_doc)]
-                        #[unsafe(no_mangle)]
+                        #[no_mangle]
                         pub unsafe extern "C" fn #fn_name_ffi(self__: savvy::ffi::SEXP, #(#args_pat: #args_ty),* ) -> savvy::ffi::SEXP {
                             #fn_name_inner(self__, #(#args_pat),*)
                         }
@@ -197,7 +197,7 @@ impl SavvyFn {
             _ => parse_quote!(
                 #(#attrs)*
                 #[allow(clippy::missing_safety_doc)]
-                #[unsafe(no_mangle)]
+                #[no_mangle]
                 pub unsafe extern "C" fn #fn_name_ffi( #(#args_pat: #args_ty),* ) -> savvy::ffi::SEXP {
                     match #fn_name_inner(#(#args_pat),*) {
                         Ok(#ok_lhs) => #ok_rhs,

--- a/savvy-bindgen/src/codegen/templates/Cargo_toml
+++ b/savvy-bindgen/src/codegen/templates/Cargo_toml
@@ -1,7 +1,7 @@
 [package]
 name = "{}"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/savvy-bindgen/src/ir/savvy_enum.rs
+++ b/savvy-bindgen/src/ir/savvy_enum.rs
@@ -1,4 +1,4 @@
-use syn::{ItemEnum, ItemImpl, parse_quote};
+use syn::{parse_quote, ItemEnum, ItemImpl};
 
 use crate::extract_docs;
 

--- a/savvy-bindgen/src/ir/savvy_fn.rs
+++ b/savvy-bindgen/src/ir/savvy_fn.rs
@@ -69,15 +69,8 @@ impl SavvyInputType {
                             ));
                         }
 
-                        if let syn::PathArguments::AngleBracketed(
-                            syn::AngleBracketedGenericArguments { args, .. },
-                        ) = &type_path_last.arguments
-                        {
-                            if args.len() == 1 {
-                                if let syn::GenericArgument::Type(ty) = &args.first().unwrap() {
-                                    return Self::from_type(ty, true);
-                                }
-                            }
+                        if let Some(ty) = single_generic_type(&type_path_last.arguments) {
+                            return Self::from_type(ty, true);
                         }
 
                         Err(syn::Error::new_spanned(
@@ -604,69 +597,72 @@ fn get_savvy_return_type(
 
             // Check `T`` in savvy::Result<T>
 
-            if let syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
-                args,
-                ..
-            }) = path_args
-            {
-                if args.len() != 1 {
-                    return e;
-                }
+            if let Some(ty) = single_generic_type(path_args) {
+                match ty {
+                    syn::Type::Tuple(type_tuple) if type_tuple.elems.is_empty() => {
+                        return Ok(SavvyFnReturnType::Unit(return_type.clone()));
+                    }
 
-                if let syn::GenericArgument::Type(ty) = &args.first().unwrap() {
-                    match ty {
-                        syn::Type::Tuple(type_tuple) if type_tuple.elems.is_empty() => {
-                            return Ok(SavvyFnReturnType::Unit(return_type.clone()));
-                        }
+                    syn::Type::Path(type_path) => {
+                        let last_ident = &type_path.path.segments.last().unwrap().ident;
+                        match last_ident.to_string().as_str() {
+                            "Sexp" => return Ok(SavvyFnReturnType::Sexp(return_type.clone())),
 
-                        syn::Type::Path(type_path) => {
-                            let last_ident = &type_path.path.segments.last().unwrap().ident;
-                            match last_ident.to_string().as_str() {
-                                "Sexp" => return Ok(SavvyFnReturnType::Sexp(return_type.clone())),
-
-                                // if it's `savvy::Result<Self>`, replace `Self` with the actual type
-                                "Self" => {
-                                    if let Some(ty_actual) = self_ty_to_actual_ty(self_ty) {
-                                        return Ok(SavvyFnReturnType::UserDefinedStruct(
-                                            UserDefinedStructReturnType {
-                                                ty: ty_actual,
-                                                return_type: parse_quote!(-> savvy::Result<#self_ty>),
-                                                wrapped_with_result: true,
-                                            },
-                                        ));
-                                    }
-                                }
-
-                                // catch common mistakes
-                                wrong_ty @ ("String" | "i32" | "usize" | "f64" | "bool") => {
-                                    let msg = format!(
-"Return type must be either (), savvy::Sexp, or a user-defined type.
-You can use .try_into() to convert {wrong_ty} to savvy::Sexp."
-                                    );
-                                    return Err(syn::Error::new_spanned(type_path, msg));
-                                }
-
-                                // if it's the actual type, use it as it is.
-                                _ => {
+                            // if it's `savvy::Result<Self>`, replace `Self` with the actual type
+                            "Self" => {
+                                if let Some(ty_actual) = self_ty_to_actual_ty(self_ty) {
                                     return Ok(SavvyFnReturnType::UserDefinedStruct(
                                         UserDefinedStructReturnType {
-                                            ty: last_ident.clone(),
-                                            return_type: return_type.clone(),
+                                            ty: ty_actual,
+                                            return_type: parse_quote!(-> savvy::Result<#self_ty>),
                                             wrapped_with_result: true,
                                         },
                                     ));
                                 }
                             }
-                        }
 
-                        _ => {}
+                            // catch common mistakes
+                            wrong_ty @ ("String" | "i32" | "usize" | "f64" | "bool") => {
+                                let msg = format!(
+"Return type must be either (), savvy::Sexp, or a user-defined type.
+You can use .try_into() to convert {wrong_ty} to savvy::Sexp."
+                                    );
+                                return Err(syn::Error::new_spanned(type_path, msg));
+                            }
+
+                            // if it's the actual type, use it as it is.
+                            _ => {
+                                return Ok(SavvyFnReturnType::UserDefinedStruct(
+                                    UserDefinedStructReturnType {
+                                        ty: last_ident.clone(),
+                                        return_type: return_type.clone(),
+                                        wrapped_with_result: true,
+                                    },
+                                ));
+                            }
+                        }
                     }
+
+                    _ => {}
                 }
             }
 
             e
         }
     }
+}
+
+/// Extracts `T` if the path arguments are exactly `<T>`
+fn single_generic_type(path_args: &syn::PathArguments) -> Option<&syn::Type> {
+    if let syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+        args, ..
+    }) = path_args
+    {
+        if let (1, Some(syn::GenericArgument::Type(ty))) = (args.len(), args.first()) {
+            return Some(ty);
+        }
+    }
+    None
 }
 
 /// check if the type path either starts with `savvy::` or no qualifier

--- a/savvy-bindgen/src/ir/savvy_fn.rs
+++ b/savvy-bindgen/src/ir/savvy_fn.rs
@@ -1,7 +1,7 @@
 use proc_macro2::Span;
 use quote::format_ident;
 use syn::{
-    Attribute, FnArg::Typed, Pat::Ident, PatType, Signature, Stmt, ext::IdentExt, parse_quote,
+    ext::IdentExt, parse_quote, Attribute, FnArg::Typed, Pat::Ident, PatType, Signature, Stmt,
 };
 
 use crate::utils::extract_docs;
@@ -72,10 +72,12 @@ impl SavvyInputType {
                         if let syn::PathArguments::AngleBracketed(
                             syn::AngleBracketedGenericArguments { args, .. },
                         ) = &type_path_last.arguments
-                            && args.len() == 1
-                            && let syn::GenericArgument::Type(ty) = &args.first().unwrap()
                         {
-                            return Self::from_type(ty, true);
+                            if args.len() == 1 {
+                                if let syn::GenericArgument::Type(ty) = &args.first().unwrap() {
+                                    return Self::from_type(ty, true);
+                                }
+                            }
                         }
 
                         Err(syn::Error::new_spanned(

--- a/savvy-bindgen/src/lib.rs
+++ b/savvy-bindgen/src/lib.rs
@@ -15,7 +15,7 @@ pub use ir::savvy_fn::{SavvyFn, SavvyFnArg, SavvyFnType};
 pub use ir::savvy_impl::SavvyImpl;
 pub use ir::savvy_struct::SavvyStruct;
 
-pub use ir::{MergedResult, ParsedResult, merge_parsed_results};
+pub use ir::{merge_parsed_results, MergedResult, ParsedResult};
 
 pub use utils::extract_docs;
 

--- a/savvy-bindgen/src/parse_file.rs
+++ b/savvy-bindgen/src/parse_file.rs
@@ -5,8 +5,8 @@ use quote::format_ident;
 use syn::{ext::IdentExt, parse_quote};
 
 use crate::{
-    ParsedResult, SavvyEnum, SavvyFn, SavvyImpl, SavvyStruct, extract_docs, ir::ParsedTestCase,
-    utils::add_indent,
+    extract_docs, ir::ParsedTestCase, utils::add_indent, ParsedResult, SavvyEnum, SavvyFn,
+    SavvyImpl, SavvyStruct,
 };
 
 fn is_savvified(attrs: &[syn::Attribute]) -> bool {

--- a/savvy-cli/Cargo.toml
+++ b/savvy-cli/Cargo.toml
@@ -9,7 +9,8 @@ repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 
-# PanicHookInfo is introduced in 1.81
+# Unlike the savvy crate (MSRV 1.81), savvy-cli requires a newer Rust because
+# the dependencies (e.g. clap, toml) use Rust 2024 edition.
 rust-version = "1.88"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/savvy-cli/Cargo.toml
+++ b/savvy-cli/Cargo.toml
@@ -9,8 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 
-# Unlike the savvy crate (MSRV 1.81), savvy-cli requires a newer Rust because
-# the dependencies (e.g. clap, toml) use Rust 2024 edition.
+# Unlike the savvy crate, savvy-cli can require a newer Rust; it's compiled on
+# CI and distributed as binaries, so this is not what the users compile. The
+# dependencies (e.g. clap, toml) require a newer Rust anyway.
 rust-version = "1.88"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/savvy-cli/src/main.rs
+++ b/savvy-cli/src/main.rs
@@ -22,10 +22,10 @@ use std::path::PathBuf;
 use futures_lite::{io::BufReader, prelude::*};
 
 use savvy_bindgen::{
-    ParsedResult, generate_c_header_file, generate_c_impl_file, generate_cargo_toml,
-    generate_cleanup, generate_config_toml, generate_configure, generate_example_lib_rs,
-    generate_gitignore, generate_makevars_in, generate_makevars_win_in, generate_r_impl_file,
-    generate_win_def,
+    generate_c_header_file, generate_c_impl_file, generate_cargo_toml, generate_cleanup,
+    generate_config_toml, generate_configure, generate_example_lib_rs, generate_gitignore,
+    generate_makevars_in, generate_makevars_win_in, generate_r_impl_file, generate_win_def,
+    ParsedResult,
 };
 
 /// Generate C bindings and R bindings for a Rust library

--- a/savvy-ffi/Cargo.toml
+++ b/savvy-ffi/Cargo.toml
@@ -3,6 +3,7 @@ name = "savvy-ffi"
 description = "Minimal FFI bindings for R's C API"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/savvy-ffi/src/altrep.rs
+++ b/savvy-ffi/src/altrep.rs
@@ -17,7 +17,7 @@ pub struct R_altrep_class_t {
 unsafe impl Send for R_altrep_class_t {}
 unsafe impl Sync for R_altrep_class_t {}
 
-unsafe extern "C" {
+extern "C" {
     // Note: this function is not limited to ALTREP, but this is placed here
     // because it's currently needed only for ALTREP.
     pub fn MARK_NOT_MUTABLE(x: SEXP);
@@ -35,7 +35,7 @@ unsafe extern "C" {
 
 // general
 
-unsafe extern "C" {
+extern "C" {
     pub fn R_set_altrep_Unserialize_method(
         cls: R_altrep_class_t,
         fun: Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP) -> SEXP>,
@@ -74,7 +74,7 @@ unsafe extern "C" {
 
 // vector common
 
-unsafe extern "C" {
+extern "C" {
     pub fn R_set_altvec_Dataptr_method(
         cls: R_altrep_class_t,
         fun: Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> *mut c_void>,
@@ -88,7 +88,7 @@ unsafe extern "C" {
 
 // integer
 
-unsafe extern "C" {
+extern "C" {
     pub fn R_make_altinteger_class(
         cname: *const c_char,
         pname: *const c_char,
@@ -133,7 +133,7 @@ unsafe extern "C" {
 
 // real
 
-unsafe extern "C" {
+extern "C" {
     pub fn R_make_altreal_class(
         cname: *const c_char,
         pname: *const c_char,
@@ -178,7 +178,7 @@ unsafe extern "C" {
 
 // logical
 
-unsafe extern "C" {
+extern "C" {
     pub fn R_make_altlogical_class(
         cname: *const c_char,
         pname: *const c_char,
@@ -214,7 +214,7 @@ unsafe extern "C" {
 }
 
 // raw
-unsafe extern "C" {
+extern "C" {
     pub fn R_make_altraw_class(
         cname: *const c_char,
         pname: *const c_char,
@@ -239,7 +239,7 @@ unsafe extern "C" {
 
 // string
 
-unsafe extern "C" {
+extern "C" {
     pub fn R_make_altstring_class(
         cname: *const c_char,
         pname: *const c_char,
@@ -265,7 +265,7 @@ unsafe extern "C" {
 
 // list
 
-unsafe extern "C" {
+extern "C" {
     pub fn R_make_altlist_class(
         cname: *const c_char,
         pname: *const c_char,

--- a/savvy-ffi/src/lib.rs
+++ b/savvy-ffi/src/lib.rs
@@ -49,19 +49,19 @@ pub const RAWSXP: SEXPTYPE = 24;
 pub const OBJSXP: SEXPTYPE = 25;
 
 // pre-defined symbols
-unsafe extern "C" {
+extern "C" {
     pub static mut R_NamesSymbol: SEXP;
     pub static mut R_ClassSymbol: SEXP;
     pub static mut R_DimSymbol: SEXP;
 }
 
 // NULL
-unsafe extern "C" {
+extern "C" {
     pub static mut R_NilValue: SEXP;
 }
 
 // NA
-unsafe extern "C" {
+extern "C" {
     pub static mut R_NaInt: ::std::os::raw::c_int;
     pub static mut R_NaReal: f64;
     pub static mut R_NaString: SEXP;
@@ -70,7 +70,7 @@ unsafe extern "C" {
 }
 
 // Allocation and attributes
-unsafe extern "C" {
+extern "C" {
     pub fn Rf_xlength(arg1: SEXP) -> R_xlen_t;
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
     pub fn Rf_getAttrib(arg1: SEXP, arg2: SEXP) -> SEXP;
@@ -78,13 +78,13 @@ unsafe extern "C" {
 }
 
 // Symbol
-unsafe extern "C" {
+extern "C" {
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 
 // Integer
-unsafe extern "C" {
+extern "C" {
     pub fn INTEGER(x: SEXP) -> *mut ::std::os::raw::c_int;
     pub fn INTEGER_RO(x: SEXP) -> *const ::std::os::raw::c_int;
     pub fn INTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
@@ -94,7 +94,7 @@ unsafe extern "C" {
 }
 
 // Real
-unsafe extern "C" {
+extern "C" {
     pub fn REAL(x: SEXP) -> *mut f64;
     pub fn REAL_RO(x: SEXP) -> *const f64;
     pub fn REAL_ELT(x: SEXP, i: R_xlen_t) -> f64;
@@ -109,7 +109,7 @@ unsafe extern "C" {
 // c_char.
 //
 // [1]: https://doc.rust-lang.org/stable/core/ffi/type.c_uchar.html
-unsafe extern "C" {
+extern "C" {
     pub fn RAW(x: SEXP) -> *mut u8;
     pub fn RAW_RO(x: SEXP) -> *const u8;
     pub fn RAW_ELT(x: SEXP, i: R_xlen_t) -> u8;
@@ -120,7 +120,7 @@ unsafe extern "C" {
 }
 
 // Numeric
-unsafe extern "C" {
+extern "C" {
     pub fn Rf_isNumeric(arg1: SEXP) -> Rboolean;
 }
 
@@ -141,7 +141,7 @@ unsafe extern "C" {
 //
 // cf. https://gitlab.com/petsc/petsc-rs/-/issues/1
 #[cfg(feature = "complex")]
-unsafe extern "C" {
+extern "C" {
     pub fn COMPLEX(x: SEXP) -> *mut num_complex::Complex64;
     pub fn COMPLEX_RO(x: SEXP) -> *mut num_complex::Complex64;
     pub fn COMPLEX_ELT(x: SEXP, i: R_xlen_t) -> num_complex::Complex64;
@@ -151,7 +151,7 @@ unsafe extern "C" {
 }
 
 // Logical
-unsafe extern "C" {
+extern "C" {
     pub fn LOGICAL(x: SEXP) -> *mut ::std::os::raw::c_int;
     pub fn LOGICAL_RO(x: SEXP) -> *const ::std::os::raw::c_int;
     pub fn LOGICAL_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
@@ -170,7 +170,7 @@ pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
 pub type cetype_t = ::std::os::raw::c_int;
 
-unsafe extern "C" {
+extern "C" {
     pub fn STRING_PTR_RO(x: SEXP) -> *const SEXP;
     pub fn STRING_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
     pub fn SET_STRING_ELT(x: SEXP, i: R_xlen_t, v: SEXP);
@@ -186,7 +186,7 @@ unsafe extern "C" {
 }
 
 // List
-unsafe extern "C" {
+extern "C" {
     pub fn VECTOR_PTR_RO(x: SEXP) -> *const ::std::os::raw::c_void;
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
     pub fn SET_VECTOR_ELT(x: SEXP, i: R_xlen_t, v: SEXP) -> SEXP;
@@ -195,7 +195,7 @@ unsafe extern "C" {
 // External pointer
 
 pub type R_CFinalizer_t = Option<unsafe extern "C" fn(arg1: SEXP)>;
-unsafe extern "C" {
+extern "C" {
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
     pub fn R_ExternalPtrAddr(s: SEXP) -> *mut ::std::os::raw::c_void;
     pub fn R_ClearExternalPtr(s: SEXP);
@@ -204,7 +204,7 @@ unsafe extern "C" {
 }
 
 // Pairlist
-unsafe extern "C" {
+extern "C" {
     pub fn Rf_cons(arg1: SEXP, arg2: SEXP) -> SEXP;
     pub fn Rf_lcons(arg1: SEXP, arg2: SEXP) -> SEXP;
     pub fn CAR(e: SEXP) -> SEXP;
@@ -216,7 +216,7 @@ unsafe extern "C" {
 }
 
 // Function and environment
-unsafe extern "C" {
+extern "C" {
     pub fn Rf_isFunction(arg1: SEXP) -> Rboolean;
     pub fn Rf_isEnvironment(arg1: SEXP) -> Rboolean;
     pub fn Rf_eval(arg1: SEXP, arg2: SEXP) -> SEXP;
@@ -228,20 +228,20 @@ unsafe extern "C" {
 }
 
 // Parse
-unsafe extern "C" {
+extern "C" {
     pub fn R_ParseEvalString(arg1: *const ::std::os::raw::c_char, arg2: SEXP) -> SEXP;
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 
 // Protection
-unsafe extern "C" {
+extern "C" {
     pub fn Rf_protect(arg1: SEXP) -> SEXP;
     pub fn Rf_unprotect(arg1: ::std::os::raw::c_int);
     pub fn R_PreserveObject(arg1: SEXP);
 }
 
 // Type
-unsafe extern "C" {
+extern "C" {
     // Note: For some reason, the return type of TYPEOF() is defined as int in
     // RInternals.h and memory.c. However, the actual implementation is
     //
@@ -260,20 +260,20 @@ unsafe extern "C" {
 }
 
 // Error
-unsafe extern "C" {
+extern "C" {
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...) -> !;
     pub fn Rf_warningcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 
 // I/O
-unsafe extern "C" {
+extern "C" {
     pub fn Rprintf(arg1: *const ::std::os::raw::c_char, ...);
     pub fn REprintf(arg1: *const ::std::os::raw::c_char, ...);
 }
 
 // misc
 pub type DllInfo = *mut ::std::os::raw::c_void;
-unsafe extern "C" {
+extern "C" {
     pub fn Rf_coerceVector(arg1: SEXP, arg2: SEXPTYPE) -> SEXP;
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
 }

--- a/savvy-macro/Cargo.toml
+++ b/savvy-macro/Cargo.toml
@@ -3,6 +3,7 @@ name = "savvy-macro"
 description = "Generate R-ready Rust functions by adding `#[savvy]` macro"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi-2.snap
+++ b/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi-2.snap
@@ -4,7 +4,7 @@ assertion_line: 194
 expression: lines
 ---
 - "#[allow(clippy::missing_safety_doc)]"
-- "#[unsafe(no_mangle)]"
+- "#[no_mangle]"
 - "pub unsafe extern \"C\" fn savvy_foo__ffi() -> savvy::ffi::SEXP {"
 - "    match savvy_foo_inner() {"
 - "        Ok(_) => savvy::sexp::null::null(),"

--- a/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi-3.snap
+++ b/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi-3.snap
@@ -4,7 +4,7 @@ assertion_line: 194
 expression: lines
 ---
 - "#[allow(clippy::missing_safety_doc)]"
-- "#[unsafe(no_mangle)]"
+- "#[no_mangle]"
 - "pub unsafe extern \"C\" fn savvy_foo__ffi("
 - "    x: savvy::ffi::SEXP,"
 - "    y: savvy::ffi::SEXP,"

--- a/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi.snap
+++ b/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi.snap
@@ -4,7 +4,7 @@ assertion_line: 194
 expression: lines
 ---
 - "#[allow(clippy::missing_safety_doc)]"
-- "#[unsafe(no_mangle)]"
+- "#[no_mangle]"
 - "pub unsafe extern \"C\" fn savvy_foo__ffi() -> savvy::ffi::SEXP {"
 - "    match savvy_foo_inner() {"
 - "        Ok(result) => result.0,"

--- a/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi_impl-2.snap
+++ b/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi_impl-2.snap
@@ -4,7 +4,7 @@ assertion_line: 227
 expression: lines
 ---
 - "#[allow(clippy::missing_safety_doc)]"
-- "#[unsafe(no_mangle)]"
+- "#[no_mangle]"
 - "pub unsafe extern \"C\" fn savvy_Person_new2__ffi() -> savvy::ffi::SEXP {"
 - "    match savvy_Person_new2_inner() {"
 - "        Ok(result) => {"

--- a/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi_impl-3.snap
+++ b/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi_impl-3.snap
@@ -4,7 +4,7 @@ assertion_line: 227
 expression: lines
 ---
 - "#[allow(clippy::missing_safety_doc)]"
-- "#[unsafe(no_mangle)]"
+- "#[no_mangle]"
 - "pub unsafe extern \"C\" fn savvy_Person_name__ffi("
 - "    self__: savvy::ffi::SEXP,"
 - ") -> savvy::ffi::SEXP {"

--- a/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi_impl-4.snap
+++ b/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi_impl-4.snap
@@ -4,7 +4,7 @@ assertion_line: 227
 expression: lines
 ---
 - "#[allow(clippy::missing_safety_doc)]"
-- "#[unsafe(no_mangle)]"
+- "#[no_mangle]"
 - "pub unsafe extern \"C\" fn savvy_Person_set_name__ffi("
 - "    self__: savvy::ffi::SEXP,"
 - "    name: savvy::ffi::SEXP,"

--- a/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi_impl.snap
+++ b/savvy-macro/src/snapshots/savvy_macro__tests__assert_snapshot_ffi_impl.snap
@@ -4,7 +4,7 @@ assertion_line: 227
 expression: lines
 ---
 - "#[allow(clippy::missing_safety_doc)]"
-- "#[unsafe(no_mangle)]"
+- "#[no_mangle]"
 - "pub unsafe extern \"C\" fn savvy_Person_new__ffi() -> savvy::ffi::SEXP {"
 - "    match savvy_Person_new_inner() {"
 - "        Ok(result) => {"

--- a/src/altrep/altinteger.rs
+++ b/src/altrep/altinteger.rs
@@ -4,9 +4,6 @@ use std::{
 };
 
 use savvy_ffi::{
-    INTEGER, INTEGER_ELT, INTSXP, R_NaInt, R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE,
-    Rboolean_TRUE, Rf_ScalarInteger, Rf_ScalarReal, Rf_coerceVector, Rf_duplicate, Rf_protect,
-    Rf_unprotect, Rf_xlength, SEXP, SEXPTYPE,
     altrep::{
         R_altrep_data2, R_make_altinteger_class, R_set_altinteger_Elt_method,
         R_set_altinteger_Max_method, R_set_altinteger_Min_method, R_set_altinteger_Sum_method,
@@ -14,6 +11,9 @@ use savvy_ffi::{
         R_set_altrep_Length_method, R_set_altrep_data2, R_set_altvec_Dataptr_method,
         R_set_altvec_Dataptr_or_null_method,
     },
+    R_NaInt, R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_ScalarInteger,
+    Rf_ScalarReal, Rf_coerceVector, Rf_duplicate, Rf_protect, Rf_unprotect, Rf_xlength, INTEGER,
+    INTEGER_ELT, INTSXP, SEXP, SEXPTYPE,
 };
 
 use crate::{IntegerSexp, IntoExtPtrSexp, NotAvailableValue};

--- a/src/altrep/altlist.rs
+++ b/src/altrep/altlist.rs
@@ -4,14 +4,14 @@ use std::{
 };
 
 use savvy_ffi::{
-    R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_coerceVector, Rf_duplicate,
-    Rf_protect, Rf_unprotect, Rf_xlength, SET_VECTOR_ELT, SEXP, SEXPTYPE, VECSXP, VECTOR_ELT,
-    VECTOR_PTR_RO,
     altrep::{
         R_altrep_data2, R_make_altlist_class, R_set_altlist_Elt_method, R_set_altrep_Coerce_method,
         R_set_altrep_Duplicate_method, R_set_altrep_Inspect_method, R_set_altrep_Length_method,
         R_set_altrep_data2, R_set_altvec_Dataptr_or_null_method,
     },
+    R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_coerceVector, Rf_duplicate,
+    Rf_protect, Rf_unprotect, Rf_xlength, SET_VECTOR_ELT, SEXP, SEXPTYPE, VECSXP, VECTOR_ELT,
+    VECTOR_PTR_RO,
 };
 
 use crate::{IntoExtPtrSexp, ListSexp};

--- a/src/altrep/altlogical.rs
+++ b/src/altrep/altlogical.rs
@@ -4,15 +4,15 @@ use std::{
 };
 
 use savvy_ffi::{
-    LGLSXP, LOGICAL, LOGICAL_ELT, R_NaInt, R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE,
-    Rboolean_TRUE, Rf_coerceVector, Rf_duplicate, Rf_protect, Rf_unprotect, Rf_xlength, SEXP,
-    SEXPTYPE,
     altrep::{
         R_altrep_data2, R_make_altlogical_class, R_set_altlogical_Elt_method,
         R_set_altrep_Coerce_method, R_set_altrep_Duplicate_method, R_set_altrep_Inspect_method,
         R_set_altrep_Length_method, R_set_altrep_data2, R_set_altvec_Dataptr_method,
         R_set_altvec_Dataptr_or_null_method,
     },
+    R_NaInt, R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_coerceVector,
+    Rf_duplicate, Rf_protect, Rf_unprotect, Rf_xlength, LGLSXP, LOGICAL, LOGICAL_ELT, SEXP,
+    SEXPTYPE,
 };
 
 use crate::{IntoExtPtrSexp, LogicalSexp};

--- a/src/altrep/altraw.rs
+++ b/src/altrep/altraw.rs
@@ -4,13 +4,13 @@ use std::{
 };
 
 use savvy_ffi::{
-    R_NilValue, R_xlen_t, RAW, RAW_ELT, RAWSXP, Rboolean, Rboolean_FALSE, Rboolean_TRUE,
-    Rf_coerceVector, Rf_duplicate, Rf_protect, Rf_unprotect, Rf_xlength, SEXP, SEXPTYPE,
     altrep::{
         R_altrep_data2, R_make_altraw_class, R_set_altraw_Elt_method, R_set_altrep_Coerce_method,
         R_set_altrep_Duplicate_method, R_set_altrep_Inspect_method, R_set_altrep_Length_method,
         R_set_altrep_data2, R_set_altvec_Dataptr_method, R_set_altvec_Dataptr_or_null_method,
     },
+    R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_coerceVector, Rf_duplicate,
+    Rf_protect, Rf_unprotect, Rf_xlength, RAW, RAWSXP, RAW_ELT, SEXP, SEXPTYPE,
 };
 
 use crate::{IntoExtPtrSexp, RawSexp};

--- a/src/altrep/altreal.rs
+++ b/src/altrep/altreal.rs
@@ -4,15 +4,15 @@ use std::{
 };
 
 use savvy_ffi::{
-    R_NaReal, R_NilValue, R_xlen_t, REAL, REAL_ELT, REALSXP, Rboolean, Rboolean_FALSE,
-    Rboolean_TRUE, Rf_ScalarReal, Rf_coerceVector, Rf_duplicate, Rf_protect, Rf_unprotect,
-    Rf_xlength, SEXP, SEXPTYPE,
     altrep::{
         R_altrep_data2, R_make_altreal_class, R_set_altreal_Elt_method, R_set_altreal_Max_method,
         R_set_altreal_Min_method, R_set_altreal_Sum_method, R_set_altrep_Coerce_method,
         R_set_altrep_Duplicate_method, R_set_altrep_Inspect_method, R_set_altrep_Length_method,
         R_set_altrep_data2, R_set_altvec_Dataptr_method, R_set_altvec_Dataptr_or_null_method,
     },
+    R_NaReal, R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_ScalarReal,
+    Rf_coerceVector, Rf_duplicate, Rf_protect, Rf_unprotect, Rf_xlength, REAL, REALSXP, REAL_ELT,
+    SEXP, SEXPTYPE,
 };
 
 use crate::{IntoExtPtrSexp, NotAvailableValue, RealSexp};

--- a/src/altrep/altstring.rs
+++ b/src/altrep/altstring.rs
@@ -4,14 +4,14 @@ use std::{
 };
 
 use savvy_ffi::{
-    R_NaString, R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_coerceVector,
-    Rf_duplicate, Rf_protect, Rf_unprotect, Rf_xlength, SET_STRING_ELT, SEXP, SEXPTYPE, STRING_ELT,
-    STRING_PTR_RO, STRSXP,
     altrep::{
         R_altrep_data2, R_make_altstring_class, R_set_altrep_Coerce_method,
         R_set_altrep_Duplicate_method, R_set_altrep_Inspect_method, R_set_altrep_Length_method,
         R_set_altrep_data2, R_set_altstring_Elt_method, R_set_altvec_Dataptr_or_null_method,
     },
+    R_NaString, R_NilValue, R_xlen_t, Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_coerceVector,
+    Rf_duplicate, Rf_protect, Rf_unprotect, Rf_xlength, SET_STRING_ELT, SEXP, SEXPTYPE, STRING_ELT,
+    STRING_PTR_RO, STRSXP,
 };
 
 use crate::{IntoExtPtrSexp, StringSexp};

--- a/src/altrep/mod.rs
+++ b/src/altrep/mod.rs
@@ -15,15 +15,15 @@ pub use altstring::*;
 use std::{collections::HashMap, sync::Mutex};
 
 use savvy_ffi::{
-    PRINTNAME, R_NilValue, Rboolean_TRUE, SEXP,
     altrep::{
-        ALTREP, MARK_NOT_MUTABLE, R_altrep_class_name, R_altrep_class_package, R_altrep_class_t,
-        R_altrep_data1, R_altrep_inherits, R_new_altrep,
+        R_altrep_class_name, R_altrep_class_package, R_altrep_class_t, R_altrep_data1,
+        R_altrep_inherits, R_new_altrep, ALTREP, MARK_NOT_MUTABLE,
     },
+    R_NilValue, Rboolean_TRUE, PRINTNAME, SEXP,
 };
 use std::sync::OnceLock;
 
-use crate::{IntoExtPtrSexp, protect::local_protect, savvy_err, sexp::utils::charsxp_to_str};
+use crate::{protect::local_protect, savvy_err, sexp::utils::charsxp_to_str, IntoExtPtrSexp};
 
 /// This stores the ALTREP class objects
 static ALTREP_CLASS_CATALOGUE: OnceLock<Mutex<HashMap<&'static str, R_altrep_class_t>>> =

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3,9 +3,8 @@ use std::ffi::CString;
 use savvy_ffi::{R_ParseEvalString, R_compute_identical, Rboolean_TRUE, SEXP};
 
 use crate::{
-    Sexp,
     protect::{self},
-    unwind_protect,
+    unwind_protect, Sexp,
 };
 
 /// A result of a function call. Since the result does not yet belong to any

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-use savvy_ffi::{R_NilValue, REprintf, Rprintf};
+use savvy_ffi::{REprintf, R_NilValue, Rprintf};
 
 use std::{ffi::CString, io::Write, os::raw::c_char};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ use std::os::raw::c_char;
 pub use error::{Error, Result};
 pub use sexp::environment::EnvironmentSexp;
 pub use sexp::external_pointer::{
-    ExternalPointerSexp, IntoExtPtrSexp, get_external_pointer_addr, take_external_pointer_value,
+    get_external_pointer_addr, take_external_pointer_value, ExternalPointerSexp, IntoExtPtrSexp,
 };
 pub use sexp::function::{FunctionArgs, FunctionSexp};
 pub use sexp::integer::{IntegerSexp, OwnedIntegerSexp};
@@ -110,14 +110,14 @@ pub use savvy_ffi::Complex64;
 
 pub use unwind_protect::unwind_protect;
 
-pub use eval::{EvalResult, assert_eq_r_code, eval_parse_text};
+pub use eval::{assert_eq_r_code, eval_parse_text, EvalResult};
 
 // re-export
 pub use savvy_macro::savvy;
 pub use savvy_macro::savvy_init;
 
 use ffi::SEXP;
-use savvy_ffi::{Rf_allocVector, Rf_mkCharLenCE, SEXPTYPE, cetype_t_CE_UTF8};
+use savvy_ffi::{cetype_t_CE_UTF8, Rf_allocVector, Rf_mkCharLenCE, SEXPTYPE};
 
 fn alloc_vector(arg1: SEXPTYPE, arg2: usize) -> crate::error::Result<SEXP> {
     unsafe { unwind_protect(|| Rf_allocVector(arg1, arg2 as _)) }

--- a/src/protect.rs
+++ b/src/protect.rs
@@ -32,8 +32,8 @@
 // worry that there still exists another instance on dropping it.
 
 use savvy_ffi::{
-    CAR, CDR, R_NilValue, R_PreserveObject, Rf_cons, Rf_protect, Rf_unprotect, SET_TAG, SETCAR,
-    SETCDR, SEXP,
+    R_NilValue, R_PreserveObject, Rf_cons, Rf_protect, Rf_unprotect, CAR, CDR, SETCAR, SETCDR,
+    SET_TAG, SEXP,
 };
 use std::sync::OnceLock;
 

--- a/src/sexp/complex.rs
+++ b/src/sexp/complex.rs
@@ -4,9 +4,9 @@ use num_complex::Complex64;
 use savvy_ffi::CPLXSXP;
 use savvy_ffi::{COMPLEX, SEXP};
 
-use super::{Sexp, impl_common_sexp_ops, impl_common_sexp_ops_owned, utils::assert_len};
-use crate::NotAvailableValue;
-use crate::protect::{self, local_protect}; // for na()
+use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, utils::assert_len, Sexp};
+use crate::protect::{self, local_protect};
+use crate::NotAvailableValue; // for na()
 
 /// An external SEXP of a complex vector.
 pub struct ComplexSexp(pub SEXP);

--- a/src/sexp/environment.rs
+++ b/src/sexp/environment.rs
@@ -12,7 +12,7 @@ use savvy_ffi::{R_GlobalEnv, R_NilValue, Rboolean_FALSE, Rboolean_TRUE, SEXP};
 // unwind_protect_wrapper.c, which passes this value through R_UnwindProtect()).
 const THE_SENTINEL_VALUE: SEXP = std::ptr::null_mut() as SEXP;
 
-use crate::{Sexp, savvy_err};
+use crate::{savvy_err, Sexp};
 
 use super::utils::str_to_symsxp;
 

--- a/src/sexp/external_pointer.rs
+++ b/src/sexp/external_pointer.rs
@@ -3,7 +3,7 @@ use savvy_ffi::{
     SEXP,
 };
 
-use crate::{Sexp, protect::local_protect};
+use crate::{protect::local_protect, Sexp};
 
 // Some notes about the design.
 //

--- a/src/sexp/function.rs
+++ b/src/sexp/function.rs
@@ -1,12 +1,11 @@
-use savvy_ffi::{CDR, R_NilValue, Rf_cons, Rf_eval, Rf_lcons, SET_TAG, SETCAR, SETCDR, SEXP};
+use savvy_ffi::{R_NilValue, Rf_cons, Rf_eval, Rf_lcons, CDR, SETCAR, SETCDR, SET_TAG, SEXP};
 
 use crate::{
-    EvalResult, ListSexp,
     protect::{self, local_protect},
-    unwind_protect,
+    unwind_protect, EvalResult, ListSexp,
 };
 
-use super::{Sexp, utils::str_to_symsxp};
+use super::{utils::str_to_symsxp, Sexp};
 
 /// An external SEXP of a function.
 pub struct FunctionSexp(pub SEXP);

--- a/src/sexp/integer.rs
+++ b/src/sexp/integer.rs
@@ -3,9 +3,9 @@ use std::ops::{Index, IndexMut};
 use savvy_ffi::{INTEGER, INTSXP, SEXP};
 
 use super::utils::assert_len;
-use super::{Sexp, impl_common_sexp_ops, impl_common_sexp_ops_owned};
-use crate::NotAvailableValue;
-use crate::protect::{self, local_protect}; // for na()
+use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
+use crate::protect::{self, local_protect};
+use crate::NotAvailableValue; // for na()
 
 /// An external SEXP of an integer vector.
 pub struct IntegerSexp(pub SEXP);

--- a/src/sexp/list.rs
+++ b/src/sexp/list.rs
@@ -64,7 +64,7 @@ impl ListSexp {
     pub fn names_iter(&self) -> std::vec::IntoIter<&'static str> {
         let names = match crate::Sexp(self.inner()).get_names() {
             Some(names) => names,
-            None => std::iter::repeat("").take(self.len()).collect(),
+            None => vec![""; self.len()],
         };
 
         names.into_iter()

--- a/src/sexp/list.rs
+++ b/src/sexp/list.rs
@@ -1,8 +1,8 @@
 use savvy_ffi::{R_NamesSymbol, Rf_setAttrib, SET_VECTOR_ELT, SEXP, VECSXP, VECTOR_ELT};
 
-use crate::{OwnedStringSexp, protect};
+use crate::{protect, OwnedStringSexp};
 
-use super::{Sexp, utils::assert_len, utils::str_to_charsxp};
+use super::{utils::assert_len, utils::str_to_charsxp, Sexp};
 
 /// An external SEXP of a list.
 pub struct ListSexp(pub SEXP);
@@ -64,7 +64,7 @@ impl ListSexp {
     pub fn names_iter(&self) -> std::vec::IntoIter<&'static str> {
         let names = match crate::Sexp(self.inner()).get_names() {
             Some(names) => names,
-            None => std::iter::repeat_n("", self.len()).collect(),
+            None => std::iter::repeat("").take(self.len()).collect(),
         };
 
         names.into_iter()

--- a/src/sexp/logical.rs
+++ b/src/sexp/logical.rs
@@ -1,6 +1,6 @@
-use savvy_ffi::{LGLSXP, LOGICAL, R_NaInt, Rboolean_TRUE, SET_LOGICAL_ELT, SEXP};
+use savvy_ffi::{R_NaInt, Rboolean_TRUE, LGLSXP, LOGICAL, SET_LOGICAL_ELT, SEXP};
 
-use super::{Sexp, impl_common_sexp_ops, impl_common_sexp_ops_owned, utils::assert_len};
+use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, utils::assert_len, Sexp};
 use crate::protect::{self, local_protect};
 
 /// An external SEXP of a logical vector.

--- a/src/sexp/mod.rs
+++ b/src/sexp/mod.rs
@@ -1,9 +1,9 @@
 use std::ffi::{CStr, CString};
 
 use savvy_ffi::{
-    EXTPTRSXP, INTEGER, R_NilValue, RAWSXP, Rboolean_TRUE, Rf_getAttrib, Rf_isEnvironment,
-    Rf_isFunction, Rf_isInteger, Rf_isLogical, Rf_isNumeric, Rf_isReal, Rf_isString, Rf_type2char,
-    Rf_xlength, SEXP, SEXPTYPE, TYPEOF, VECSXP,
+    R_NilValue, Rboolean_TRUE, Rf_getAttrib, Rf_isEnvironment, Rf_isFunction, Rf_isInteger,
+    Rf_isLogical, Rf_isNumeric, Rf_isReal, Rf_isString, Rf_type2char, Rf_xlength, EXTPTRSXP,
+    INTEGER, RAWSXP, SEXP, SEXPTYPE, TYPEOF, VECSXP,
 };
 
 use crate::{

--- a/src/sexp/numeric.rs
+++ b/src/sexp/numeric.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::{IntegerSexp, NotAvailableValue, RealSexp, Sexp, savvy_err};
+use crate::{savvy_err, IntegerSexp, NotAvailableValue, RealSexp, Sexp};
 
 // --- Utils -------------------------
 
@@ -33,7 +33,11 @@ fn try_cast_f64_to_i32(f: f64) -> crate::Result<i32> {
 }
 
 fn cast_i32_to_f64(i: i32) -> f64 {
-    if i.is_na() { f64::na() } else { i as f64 }
+    if i.is_na() {
+        f64::na()
+    } else {
+        i as f64
+    }
 }
 
 fn try_cast_i32_to_usize(i: i32) -> crate::error::Result<usize> {

--- a/src/sexp/raw.rs
+++ b/src/sexp/raw.rs
@@ -3,7 +3,7 @@ use std::ops::{Index, IndexMut};
 use savvy_ffi::{RAW, RAWSXP, SEXP};
 
 use super::utils::assert_len;
-use super::{Sexp, impl_common_sexp_ops, impl_common_sexp_ops_owned};
+use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
 use crate::protect::{self, local_protect};
 
 /// An external SEXP of a raw vector.

--- a/src/sexp/real.rs
+++ b/src/sexp/real.rs
@@ -3,9 +3,9 @@ use std::ops::{Index, IndexMut};
 use savvy_ffi::{REAL, REALSXP, SEXP};
 
 use super::utils::assert_len;
-use super::{Sexp, impl_common_sexp_ops, impl_common_sexp_ops_owned};
-use crate::NotAvailableValue;
-use crate::protect::{self, local_protect}; // for na()
+use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
+use crate::protect::{self, local_protect};
+use crate::NotAvailableValue; // for na()
 
 /// An external SEXP of a real vector.
 pub struct RealSexp(pub SEXP);

--- a/src/sexp/string.rs
+++ b/src/sexp/string.rs
@@ -2,7 +2,7 @@ use savvy_ffi::{R_NaString, SET_STRING_ELT, SEXP, STRING_ELT, STRSXP};
 
 use super::na::NotAvailableValue;
 use super::utils::{assert_len, charsxp_to_str, str_to_charsxp};
-use super::{Sexp, impl_common_sexp_ops, impl_common_sexp_ops_owned};
+use super::{impl_common_sexp_ops, impl_common_sexp_ops_owned, Sexp};
 use crate::protect::{self, local_protect};
 
 /// An external SEXP of a character vector.

--- a/src/sexp/utils.rs
+++ b/src/sexp/utils.rs
@@ -3,9 +3,9 @@ use std::{
     os::raw::c_char,
 };
 
-use savvy_ffi::{R_CHAR, Rf_mkCharLenCE, Rf_xlength, SEXP, cetype_t_CE_UTF8};
+use savvy_ffi::{cetype_t_CE_UTF8, Rf_mkCharLenCE, Rf_xlength, R_CHAR, SEXP};
 
-use crate::{NotAvailableValue, savvy_err};
+use crate::{savvy_err, NotAvailableValue};
 
 pub(crate) fn assert_len(len: usize, i: usize) -> crate::error::Result<()> {
     if i >= len {

--- a/src/unwind_protect.rs
+++ b/src/unwind_protect.rs
@@ -2,7 +2,7 @@ use std::os::raw::c_void;
 
 use savvy_ffi::SEXP;
 
-unsafe extern "C" {
+extern "C" {
     fn unwind_protect_impl(
         fun: Option<unsafe extern "C" fn(data: *mut c_void) -> SEXP>,
         data: *mut c_void,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -30,11 +30,16 @@ show            show bindgen-generated bindings
 fn show() -> Result<(), DynError> {
     println!("cargo:rerun-if-changed=wrapper.h");
 
-    let builder = bindgen::Builder::default().header("wrapper.h").clang_args([
-        // TODO: this works only on my Windows laptop...
-        format!("-I{}", "C:/Program Files/R/R-devel/include"),
-        // format!("--target={target}"),
-    ]);
+    let builder = bindgen::Builder::default()
+        .header("wrapper.h")
+        // Match savvy's MSRV so that the generated bindings don't contain
+        // newer syntax (e.g. `unsafe extern` blocks, which require 1.82)
+        .rust_target(bindgen::RustTarget::stable(81, 0).map_err(|e| e.to_string())?)
+        .clang_args([
+            // TODO: this works only on my Windows laptop...
+            format!("-I{}", "C:/Program Files/R/R-devel/include"),
+            // format!("--target={target}"),
+        ]);
 
     let builder = builder
         // Basic types and variables


### PR DESCRIPTION
This is a part of the attempt to make savvy CRAN-compatible.

I once bumped MSRV to 1.88 in https://github.com/yutannihilation/savvy/pull/438, but this pull request reverts it for now. Most of the changes are due to the difference of `cargo fmt` Rust 2021 vs Rust 2024.