### PR TITLE
feat: Support R 4.2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,7 @@ jobs:
           - { os: "ubuntu-latest",    r: "release",  rust: "stable" }
           - { os: "ubuntu-latest",    r: "devel",    rust: "stable", http-user-agent: "release" }
           - { os: "ubuntu-latest",    r: "release",  rust: "nightly" }
-          - { os: "ubuntu-latest",    r: "oldrel-4", rust: "stable" }
+          - { os: "ubuntu-latest",    r: "oldrel-4", rust: "stable", no_altrep: true }
           - { os: "ubuntu-24.04-arm", r: "release",  rust: "stable", rspm: "false"}
 
     env:
@@ -59,6 +59,19 @@ jobs:
             github::yutannihilation/savvy-helper-R-package
           needs: check
           working-directory: R-package
+
+      # TODO: The `altrep` feature requires R >= 4.3.
+      - name: Remove ALTREP from R-package
+        if: ${{ matrix.config.no_altrep }}
+        run: |
+          sed -i 's/^savvy = { path = "..\/..\/..\/", features = \[.*\] }$/savvy = { path = "..\/..\/..\/", features = ["complex", "logger"] }/' R-package/src/rust/Cargo.toml
+          sed -i '/^mod altrep;$/d' R-package/src/rust/src/lib.rs
+          rm R-package/src/rust/src/altrep.rs
+          rm R-package/tests/testthat/test-altrep.R
+
+          cargo run --manifest-path ./savvy-cli/Cargo.toml -- update ./R-package
+
+          git diff --stat
 
       - name: Run cargo test
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,14 +23,15 @@ jobs:
       matrix:
         config:
           # prettier-ignore
-          - { os: "macos-latest",     r: "release", rust: "stable" }
-          - { os: "macos-15-intel",   r: "release", rust: "stable" }
-          - { os: "windows-latest",   r: "release", rust: "stable" }
-          - { os: "windows-11-arm",   r: "release", rust: "stable", rust_target: "aarch64-pc-windows-gnullvm" }
-          - { os: "ubuntu-latest",    r: "release", rust: "stable" }
-          - { os: "ubuntu-latest",    r: "devel",   rust: "stable", http-user-agent: "release" }
-          - { os: "ubuntu-latest",    r: "release", rust: "nightly" }
-          - { os: "ubuntu-24.04-arm", r: "release", rust: "stable", rspm: "false"}
+          - { os: "macos-latest",     r: "release",  rust: "stable" }
+          - { os: "macos-15-intel",   r: "release",  rust: "stable" }
+          - { os: "windows-latest",   r: "release",  rust: "stable" }
+          - { os: "windows-11-arm",   r: "release",  rust: "stable", rust_target: "aarch64-pc-windows-gnullvm" }
+          - { os: "ubuntu-latest",    r: "release",  rust: "stable" }
+          - { os: "ubuntu-latest",    r: "devel",    rust: "stable", http-user-agent: "release" }
+          - { os: "ubuntu-latest",    r: "release",  rust: "nightly" }
+          - { os: "ubuntu-latest",    r: "oldrel-4", rust: "stable" }
+          - { os: "ubuntu-24.04-arm", r: "release",  rust: "stable", rspm: "false"}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
-### Breaking changes
+### Major changes
 
-- savvy now requires R >= 4.5. Building against an older R now fails with an explicit error (#458).
-- Lower the MSRV of the savvy crate to 1.81 by reverting to Rust 2021 edition.
+- Savvy supports older R (>= 4.2) and Rust (>= 1.81), reverting the Rust edition to 2021 (#461).
+  - Note that, while most of the features work with R >= 4.2, the `altrep` feature requires R >= 4.3.
 
 ### Minor improvements
 

--- a/book/src/altrep.md
+++ b/book/src/altrep.md
@@ -11,6 +11,16 @@ You can implement an ALTREP class using savvy.
   the vector is materialized (i.e., allocated as a normal `SEXP` and put into
   the `data2` slot of the ALTREP object).
 
+* **The `altrep` feature requires R >= 4.3.** While savvy itself supports R >=
+  4.2, the ALTLIST API (which `AltList` relies on) was added in R 4.3.0. The
+  Rust code still compiles against R 4.2, but the package fails to load with an
+  undefined symbol error like `_R_make_altlist_class`. If you need to support R
+  4.2, don't enable the `altrep` feature.
+
+  ```toml
+  savvy = { version = "...", features = ["altrep"] } # requires R >= 4.3
+  ```
+
 ## Using ALTREP
 
 Savvy currently provides only the following traits for ALTREP. The other ALTREPs

--- a/savvy-ffi/src/backports/backports.c
+++ b/savvy-ffi/src/backports/backports.c
@@ -4,11 +4,11 @@
 #include <Rinternals.h>
 #include <R_ext/Altrep.h>
 
-// savvy requires R >= 4.5 (e.g. for R_getVarEx()). Without this check, building
-// against an older R succeeds and the package fails at load time with an
-// undefined symbol error, which is much harder to understand.
-#if R_VERSION < R_Version(4, 5, 0)
-#error "savvy requires R 4.5.0 or later"
+// savvy requires R >= 4.2 (e.g. for R_existsVarInFrame()). Without this check,
+// building against an older R succeeds and the package fails at load time with
+// an undefined symbol error, which is much harder to understand.
+#if R_VERSION < R_Version(4, 2, 0)
+#error "savvy requires R 4.2.0 or later"
 #endif
 
 #if R_VERSION < R_Version(4, 6, 0)
@@ -19,5 +19,38 @@ SEXP R_altrep_class_name(SEXP x)
 SEXP R_altrep_class_package(SEXP x)
 {
     return ALTREP(x) ? CADR(ATTRIB(ALTREP_CLASS(x))) : R_NilValue;
+}
+#endif
+
+#if R_VERSION < R_Version(4, 5, 0)
+const void *VECTOR_PTR_RO(SEXP x)
+{
+    return DATAPTR_RO(x);
+}
+
+SEXP R_getVarEx(SEXP sym, SEXP rho, Rboolean inherits, SEXP ifnotfound)
+{
+    SEXP val;
+
+    if (inherits) {
+        val = Rf_findVar(sym, rho);
+        if (val == R_UnboundValue)
+            return ifnotfound;
+    } else {
+        if (R_existsVarInFrame(rho, sym) != TRUE)
+            return ifnotfound;
+        // Note: unlike the inherits case, there's no API to get the value
+        // without forcing it, so let Rf_eval() do the lookup and the forcing.
+        return Rf_eval(sym, rho);
+    }
+
+    // A promise needs to be forced to get the value.
+    if (TYPEOF(val) == PROMSXP) {
+        PROTECT(val);
+        val = Rf_eval(val, rho);
+        UNPROTECT(1);
+    }
+
+    return val;
 }
 #endif


### PR DESCRIPTION
It seems there are only three APIs that needs to be backported.

1. `VECTOR_PTR_RO`
2. `R_getVarEx`
3. ALTLIST-related APIS

Among these, 1 and 2 were easy to implement. However, 3 is hard since the ALTREP itself doesn't exist on R 4.2. While it's possible to detect the R version and switch by feature flags on `build.rs`, I want to avoid it if possible. Since, fortunately or unfortunately, ALTREP is a less popular feature, so I decided to let `altrep` feature break with R 4.2.