### PR TITLE
fix: PROTECT value in `OwnedListSexp::set_name_and_value()` for safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 [ARM64 Windows]: https://contributor.r-project.org/windows-arm64/#rust-support
 [`configure.win`]: https://github.com/yutannihilation/savvy/blob/main/savvy-bindgen/src/codegen/templates/configure.win
 
+### Bug fixes
+
+- `OwnedListSexp::set_name_and_value()` now protects the input value from getting GC-ed (#462).
+
 ## [v0.10.2] (2026-04-23)
 
 ### Minor improvements

--- a/src/sexp/list.rs
+++ b/src/sexp/list.rs
@@ -185,8 +185,6 @@ impl OwnedListSexp {
 
         self.set_name(i, k)?;
 
-        drop(_sexp_guard);
-
         // cast unchecked function since set_name already does bounds check.
         unsafe { self.set_value_unchecked(i, v_sexp) };
         Ok(())

--- a/src/sexp/list.rs
+++ b/src/sexp/list.rs
@@ -1,6 +1,9 @@
 use savvy_ffi::{R_NamesSymbol, Rf_setAttrib, SET_VECTOR_ELT, SEXP, VECSXP, VECTOR_ELT};
 
-use crate::{protect, OwnedStringSexp};
+use crate::{
+    protect::{self, local_protect},
+    OwnedStringSexp,
+};
 
 use super::{utils::assert_len, utils::str_to_charsxp, Sexp};
 
@@ -175,9 +178,15 @@ impl OwnedListSexp {
         k: &str,
         v: T,
     ) -> crate::error::Result<()> {
+        // set_name might cause GC, so, convert to SEXP first, and PROTECT it
+        // cf. https://github.com/yutannihilation/savvy/issues/462
+        let v_sexp: SEXP = v.into().0;
+        let _sexp_guard = local_protect(v_sexp);
+
         self.set_name(i, k)?;
+
         // cast unchecked function since set_name already does bounds check.
-        unsafe { self.set_value_unchecked(i, v.into().0) };
+        unsafe { self.set_value_unchecked(i, v_sexp) };
         Ok(())
     }
 

--- a/src/sexp/list.rs
+++ b/src/sexp/list.rs
@@ -185,6 +185,8 @@ impl OwnedListSexp {
 
         self.set_name(i, k)?;
 
+        drop(_sexp_guard);
+
         // cast unchecked function since set_name already does bounds check.
         unsafe { self.set_value_unchecked(i, v_sexp) };
         Ok(())


### PR DESCRIPTION
Fix #462 

`v` might not be PROTECT-ed outside, so PROTECT it before calling `set_name()`, which can invoke GC.