### PR TITLE
ci: Try windows-11-vs2026-arm

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,7 +26,7 @@ jobs:
           - { os: "macos-latest",     r: "release",  rust: "stable" }
           - { os: "macos-15-intel",   r: "release",  rust: "stable" }
           - { os: "windows-latest",   r: "release",  rust: "stable" }
-          - { os: "windows-11-arm",   r: "release",  rust: "stable", rust_target: "aarch64-pc-windows-gnullvm" }
+          - { os: "windows-11-vs2026-arm", r: "release",  rust: "stable", rust_target: "aarch64-pc-windows-gnullvm" }
           - { os: "ubuntu-latest",    r: "release",  rust: "stable" }
           - { os: "ubuntu-latest",    r: "devel",    rust: "stable", http-user-agent: "release" }
           - { os: "ubuntu-latest",    r: "release",  rust: "nightly" }


### PR DESCRIPTION
ARM64 Windows runner will be updated next month. Try using it to see confirm there will be no problem.

cf. https://github.blog/changelog/2026-08-20-windows-11-arm64-vs2026-image-generally-available/