### PR TITLE
ci: Use release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,61 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'yutannihilation' }} # Do not run this on a fork
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write # Required for OIDC token exchange
+    steps:
+      - &checkout
+        name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - &install-rust
+        name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          # Since events triggered by the GITHUB_TOKEN will not trigger another
+          # workflow run, we use different PAT in order to let cargo-dist work.
+          # This is the official workaround that the GitHub document suggests.
+          # cf. https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'yutannihilation' }} # Do not run this on a fork
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - *checkout
+      - *install-rust
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,14 @@
 [workspace]
-# release-plz creates the tag
-git_tag_enable = true
+# release-plz creates the tag, but we only need one tag. So, set the workspace
+# setting of git_tag_enable to false, and set this true only on the savvy crate.
+git_tag_enable = false
 # cargo-dist creates the GitHub Release
 git_release_enable = false
 
 # I prefer manually update the CHANGELOG for now
 changelog_update = false
+
+[[package]]
+name = "savvy"
+git_tag_enable = true
+git_tag_name = "v{{ version }}"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,8 @@
+[workspace]
+# release-plz creates the tag
+git_tag_enable = true
+# cargo-dist creates the GitHub Release
+git_release_enable = false
+
+# I prefer manually update the CHANGELOG for now
+changelog_update = false


### PR DESCRIPTION
Use [release-plz](https://release-plz.dev/) along with the existing cargo-dist setup.

After this pull request, the release workflow will be:

- (The `release-plz-pr` job creates a pull request to bump the version)
- Merge the pull request, then `release-plz-release` is invoked
- A new tag is created and pushed to main, so that cargo-dist is invoked.
- The cargo-dist job creates a GitHub Release with the binary.

A few notes:

- In order to invoke cargo-dist from the tag event created by release-plz, we need to use a dedicated PAT because the repository's `GITHUB_ACTION` doesn't trigger another workflow. (cf. [official doc](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow))
- When releasing a beta version, I need to bump version manually by e.g. `release-plz set-version 1.2.3-beta.1` on local.
- This pull request also introduces trusted publishing.