### PR TITLE
chore: release v0.10.3-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["/book", "/R-package", "README.qmd"]
 rust-version.workspace = true
 
 [dependencies]
-savvy-ffi = { version = "0.10.3-rc.1", path = "./savvy-ffi" }
-savvy-macro = { version = "0.10.3-rc.1", path = "./savvy-macro" }
+savvy-ffi = { version = "0.10.3-rc.2", path = "./savvy-ffi" }
+savvy-macro = { version = "0.10.3-rc.2", path = "./savvy-macro" }
 num-complex = { version = "0.4.5", optional = true }
 
 log = { version = "0.4", optional = true }
@@ -66,7 +66,7 @@ members = ["savvy-macro", "savvy-bindgen", "savvy-cli", "savvy-ffi", "xtask"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.3-rc.1"
+version = "0.10.3-rc.2"
 edition = "2021"
 # std::panic::PanicHookInfo, which savvy relies on, is introduced in 1.81
 rust-version = "1.81"

--- a/savvy-cli/Cargo.toml
+++ b/savvy-cli/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4", features = ["derive"] }
 async-process = "2"
 futures-lite = "2"
 
-savvy-bindgen = { version = "0.10.3-rc.1", path = "../savvy-bindgen", features = [
+savvy-bindgen = { version = "0.10.3-rc.2", path = "../savvy-bindgen", features = [
     "use_formatter",
 ] }
 dirs = "6"

--- a/savvy-macro/Cargo.toml
+++ b/savvy-macro/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "3", features = ["full", "extra-traits"] }
 
-savvy-bindgen = { version = "0.10.3-rc.1", path = "../savvy-bindgen" }
+savvy-bindgen = { version = "0.10.3-rc.2", path = "../savvy-bindgen" }
 
 [dev-dependencies]
 trybuild = "1"


### PR DESCRIPTION



## 🤖 New release

* `savvy-bindgen`: 0.10.3-rc.1 -> 0.10.3-rc.2
* `savvy-macro`: 0.10.3-rc.1 -> 0.10.3-rc.2
* `savvy-cli`: 0.10.3-rc.1 -> 0.10.3-rc.2
* `savvy-ffi`: 0.10.3-rc.1 -> 0.10.3-rc.2
* `savvy`: 0.10.3-rc.1 -> 0.10.3-rc.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).